### PR TITLE
Ch 317: Allow access to explore-rate

### DIFF
--- a/css/acquia_lift.admin.css
+++ b/css/acquia_lift.admin.css
@@ -12,3 +12,26 @@
     margin-right: .3em; /* LTR */
     font-size: 1.3em;
 }
+
+.acquia-lift-more-information.horizontal .form-item {
+  float: left;
+  margin: 1em;
+  width: 40%;
+}
+
+.acquia-lift-more-information.horizontal .form-item label {
+  display: inline;
+}
+
+.acquia-lift-toggle-text {
+  float: right;
+  margin-left: 1em;
+}
+
+.form-disabled input.form-text.acquia-lift-percentage-rest {
+  color: inherit;
+  border: inherit;
+  background-color: inherit;
+  font-size: 1em;
+  width: 1.5em;
+}

--- a/includes/acquia_lift.classes.inc
+++ b/includes/acquia_lift.classes.inc
@@ -306,16 +306,20 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface {
    * @param $control_rate
    *   A number between 0 and 1 inclusive representing the percentage to use as a
    *   control group.
+   * @param $explore_rate
+   *   A number between 0 and 1 inclusive representing the percentage to use as
+   *   the continuous experiment group.
    * @return boolean
    *   TRUE if the agent has been saved to Acquia Lift, FALSE otherwise.
    */
-  public function saveAgent($machine_name, $label, $decision_style, $status = 'enabled', $control_rate = 0) {
+  public function saveAgent($machine_name, $label, $decision_style, $status = 'enabled', $control_rate = 0.1, $explore_rate = .2) {
     $url = $this->generateEndpoint("/agent-api/$machine_name");
     $agent = array(
       'name' => $label,
       'selection-mode' => $decision_style,
       'status' => $status,
       'control-rate' => $control_rate,
+      'explore-rate' => $explore_rate,
     );
     $response = $this->httpClient()->put($url, array('Content-Type' => 'application/json; charset=utf-8', 'Accept' => 'application/json'), $agent);
     $data = json_decode($response->data, TRUE);

--- a/js/acquia_lift.agent.admin.js
+++ b/js/acquia_lift.agent.admin.js
@@ -1,0 +1,60 @@
+(function ($) {
+  /**
+   * Allows one control to adjust the percentage while another
+   * displays the amount left.
+   */
+  Drupal.behaviors.acquiaLiftAgentPercentageControls = {
+    attach: function(context, settings) {
+      $('.acquia-lift-agent-percentage-adjust', context).once(function() {
+        var restId = $(this).attr('data-acquia-lift-percentage-rest');
+        var $rest = $('#' + restId, context);
+
+        // Limit input to numbers and decimal sign.
+        $(this).keyup(function(e) {
+          var code = e.keyCode || e.which;
+          // Don't apply behavior to tab, enter, or arrow keys.
+          if (code == 9 || code == 13 || (code >= 37 && code <= 40)) { return; }
+
+          this.value = this.value.replace(/[^0-9\.]/g, '');
+        });
+
+        // Update the "rest" percentage box when percentage changes.
+        $(this).change(function(e) {
+          var newPercent = $(this).val();
+          var newRest = 100 - $(this).val();
+          $rest.val(newRest);
+        });
+      })
+    }
+  };
+
+  Drupal.behaviors.acquiaLiftShowHide = {
+    attach: function(context, settings) {
+      $('.acquia-lift-more-information').once(function() {
+        var $parent = $(this);
+        if (this.tagName.toLowerCase() == 'fieldset') {
+          $parent = $('.fieldset-wrapper', this);
+        }
+        $parent.prepend('<a class="acquia-lift-toggle-text" href="#">' + Drupal.t('Info') + '</span>');
+
+        $('.acquia-lift-toggle-text', this).click(function(e) {
+          if ($(this).hasClass('collapsed')) {
+            // Open and show additional details.
+            $('.description', $parent).slideDown();
+            $(this).removeClass('collapsed');
+            $(this).text(Drupal.t('Hide info'));
+          } else {
+            $(this).addClass('collapsed');
+            $('.description', $parent).slideUp();
+            $(this).text(Drupal.t('Info'));
+          }
+          return false;
+        });
+
+        // Hide all the descriptions by default
+        $('.acquia-lift-toggle-text', this).addClass('collapsed');
+        $('.description', $parent).hide();
+      });
+    }
+  }
+})(jQuery);

--- a/plugins/agent_types/AcquiaLiftAgent.inc
+++ b/plugins/agent_types/AcquiaLiftAgent.inc
@@ -183,7 +183,45 @@ class AcquiaLiftAgent extends PersonalizeAgentBase implements AcquiaLiftAgentInt
     $form['#attached'] = array(
       'css' => array(
         drupal_get_path('module', 'acquia_lift') . '/css/personalize_acquia_lift_admin.css',
-      )
+      ),
+      'js' => array(
+        drupal_get_path('module', 'acquia_lift') . '/js/acquia_lift.agent.admin.js',
+      ),
+    );
+    $form['control'] = array(
+      '#type' => 'fieldset',
+      '#collapsible' => TRUE,
+      '#collapsed' => TRUE,
+      '#attributes' => array('class' => array(
+        'horizontal',
+        'acquia-lift-more-information',
+      )),
+      '#title' => t('Control'),
+    );
+    $form['control']['control_rate'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Control Group'),
+      '#field_suffix' => '%',
+      '#size' => 3,
+      '#description' => t('A fixed baseline variation will be shown, by default the first variation in the set.'),
+      '#default_value' => isset($agent_data->data['control']['control_rate']) ? $agent_data->data['control']['control_rate'] : 10,
+      '#attributes' => array(
+        'class' => array('acquia-lift-agent-percentage-adjust'),
+        'data-acquia-lift-percentage-rest' => 'acquia-lift-control-rate-rest',
+      ),
+    );
+    $form['control']['group_rate'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Test Group'),
+      '#field_suffix' => '%',
+      '#size' => 3,
+      '#description' => t('Personalized variations will be shown.'),
+      '#default_value' => isset($agent_data->data['control']['control_rate']) ? (100 - $agent_data->data['control']['control_rate']) : 90,
+      '#disabled' => TRUE,
+      '#attributes' => array(
+        'id' => 'acquia-lift-control-rate-rest',
+        'class' => array('acquia-lift-percentage-rest'),
+      ),
     );
     $form['decision_style'] = array(
       '#type' => 'radios',
@@ -193,13 +231,45 @@ class AcquiaLiftAgent extends PersonalizeAgentBase implements AcquiaLiftAgentInt
       '#description' => t('Auto personalize chooses the best option over time, test just shows variations and reports results'),
       '#title_display' => 'invisible',
     );
-    $form['control_rate'] = array(
+    $form['distribution'] = array(
+      '#type' => 'fieldset',
+      '#collapsible' => TRUE,
+      '#collapsed' => TRUE,
+      '#attributes' => array('class' => array(
+        'horizontal',
+        'acquia-lift-more-information',
+      )),
+      '#title' => t('Distribution'),
+      '#states' => array(
+        'visible' => array(
+          ':input[name="agent_basic_info[options][acquia_lift][decision_style]"]' => array('value' => 'adaptive'),
+        ),
+      ),
+    );
+    $form['distribution']['explore_rate'] = array(
       '#type' => 'textfield',
-      '#title' => t('Percent to test'),
-      '#field_suffix' => t('% of visitors will see content variables, the rest will see the default (the first variation).)'),
-      '#size' => 4,
-      '#description' => t('Use this to test against a baseline or "control" group, otherwise keep it set to 100.'),
-      '#default_value' => isset($agent_data->data['control_rate']) ? $agent_data->data['control_rate'] : 100,
+      '#title' => t('Random Group'),
+      '#field_suffix' => '%',
+      '#description' => t('Variations will be shown randomly and tracked to adjust for false positives.'),
+      '#size' => 3,
+      '#default_value' => isset($agent_data->data['distribution']['explore_rate']) ? $agent_data->data['distribution']['explore_rate'] : 20,
+      '#attributes' => array(
+        'class' => array('acquia-lift-agent-percentage-adjust'),
+        'data-acquia-lift-percentage-rest' => 'acquia-lift-explore-rate-rest',
+      ),
+    );
+    $form['distribution']['exploit_rate'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Personalized Group'),
+      '#field_suffix' => '%',
+      '#size' => 3,
+      '#description' => t('The "best" variation will be shown for each visitor based on our algorithm.'),
+      '#default_value' => isset($agent_data->data['distribution']['explore_rate']) ? (100 - $agent_data->data['distribution']['explore_rate']) : 80,
+      '#disabled' => TRUE,
+      '#attributes' => array(
+        'id' => 'acquia-lift-explore-rate-rest',
+        'class' => array('acquia-lift-percentage-rest'),
+      )
     );
     return $form;
   }
@@ -209,10 +279,16 @@ class AcquiaLiftAgent extends PersonalizeAgentBase implements AcquiaLiftAgentInt
    */
   public static function optionsFormValidate($form, &$form_state) {
     $values = $form_state['values']['agent_basic_info'];
-    if (isset($values['options']['acquia_lift']) && isset($values['options']['acquia_lift']['control_rate'])) {
-      $rate = $values['options']['acquia_lift']['control_rate'];
+    if (isset($values['options']['acquia_lift']) && isset($values['options']['acquia_lift']['control']['control_rate'])) {
+      $rate = $values['options']['acquia_lift']['control']['control_rate'];
       if (!is_numeric($rate) || !($rate >= 0 && $rate <= 100)) {
-        form_set_error('agent_basic_info][options][acquia_lift][control_rate', t('Invalid percent to test specified'));
+        form_set_error('agent_basic_info][options][acquia_lift][control][control_rate', t('Invalid percent to test specified'));
+      }
+    }
+    if (isset($values['options']['acquia_lift']) && isset($values['options']['acquia_lift']['distribution']['explore_rate'])) {
+      $rate = $values['options']['acquia_lift']['distribution']['explore_rate'];
+      if (!is_numeric($rate) || !($rate >= 0 && $rate <= 100)) {
+        form_set_error('agent_basic_info][options][acquia_lift][distribution][explore_rate', t('Invalid percent to test specified'));
       }
     }
     return;
@@ -223,12 +299,23 @@ class AcquiaLiftAgent extends PersonalizeAgentBase implements AcquiaLiftAgentInt
    */
   public function postSave($old_data) {
     $items = array();
-    $acquia_lift_control_rate = 0;
-    if (isset($this->data['control_rate'])) {
+    $acquia_lift_control_rate = .1;
+    $acquia_lift_explore_rate = .2;
+    dpm($this->data, 'postSave data');
+    if (isset($this->data['control']['control_rate'])) {
       // Acquia Lift takes the control rate as a number between 0 and 1.
-      // The value represents the control rate (0=no control group) rather than
-      // the percent to test (where 100=no control group).
-      $acquia_lift_control_rate = (100 - $this->data['control_rate']) / 100;
+      $acquia_lift_control_rate = $this->data['control']['control_rate'] / 100;
+    }
+    if (isset($this->data['distribution']['explore_rate']) && isset($this->data['decision_style'])) {
+      if ($this->data['decision_style'] === 'adaptive') {
+        // Acquia Lift takes the explore rate as a number between 0 and 1.
+        $acquia_lift_explore_rate = $this->data['distribution']['explore_rate'] / 100;
+      }
+      else {
+        // If the decision style is to only test, then the explore rate is the
+        // full group.
+        $acquia_lift_explore_rate = 1;
+      }
     }
     // Add an item for saving the agent to Acquia Lift.
     $items[] = array(
@@ -239,6 +326,7 @@ class AcquiaLiftAgent extends PersonalizeAgentBase implements AcquiaLiftAgentInt
         $this->data['decision_style'],
         'enabled',
         $acquia_lift_control_rate,
+        $acquia_lift_explore_rate,
       ),
     );
     $acquia_lift_context_needs_deleting = isset($old_data->data['visitor_context']['acquia_lift_context']);
@@ -316,7 +404,7 @@ class AcquiaLiftAgent extends PersonalizeAgentBase implements AcquiaLiftAgentInt
     );
     // We only show the lift over default if we are using a non-zero percentage of
     // users as a control group.
-    $show_default = isset($this->data['control_rate']) && (int) $this->data['control_rate'] > 0;
+    $show_default = isset($this->data['control']['control_rate']) && (int) $this->data['control']['control_rate'] > 0;
     if ($show_default) {
       $header[] = t('Lift over default');
     }

--- a/tests/AcquiaLiftAPI.test
+++ b/tests/AcquiaLiftAPI.test
@@ -1370,7 +1370,8 @@ class AcquiaLiftTest extends DrupalUnitTestCase {
           'name' => 'Some Test Agent',
           'selection-mode' => 'adaptive',
           'status' => 'enabled',
-          'control-rate' => 0,
+          'control-rate' => 0.1,
+          'explore-rate' => 0.2,
         )
       )
     );
@@ -1386,7 +1387,7 @@ class AcquiaLiftTest extends DrupalUnitTestCase {
     $this->assertLogs($logs);
     $this->logger->clearLogs();
 
-    $lift_api->saveAgent('some-test-agent', 'Some Test Agent', 'adaptive', 'enabled', 0.1);
+    $lift_api->saveAgent('some-test-agent', 'Some Test Agent', 'adaptive', 'enabled', 0.1, 0.4);
     // Define the requests we expect to have been made to our dummy http
     // client for this operation.
     $requests = array(
@@ -1400,6 +1401,7 @@ class AcquiaLiftTest extends DrupalUnitTestCase {
           'selection-mode' => 'adaptive',
           'status' => 'enabled',
           'control-rate' => 0.1,
+          'explore-rate' => 0.4,
         )
       )
     );
@@ -1410,7 +1412,7 @@ class AcquiaLiftTest extends DrupalUnitTestCase {
 
     // Now try with a broken http client.
     $lift_api = $this->getAcquiaLiftAPI(TRUE);
-    $lift_api->saveAgent('some-test-agent', 'Some Test Agent', 'adaptive', 'enabled', 0.1);
+    $lift_api->saveAgent('some-test-agent', 'Some Test Agent', 'adaptive', 'enabled', 0.1, 0.4);
     // The same requests should be made.
     $this->assertAPIRequests($requests);
     // Confirm the expected error message was logged.

--- a/tests/acquia_lift.test
+++ b/tests/acquia_lift.test
@@ -100,7 +100,7 @@ class AcquiaLiftWebTest extends DrupalWebTestCase {
 
   public function testSaveAgent() {
     // Create a new agent via the UI.
-    $agent = $this->createTestAgent(array('control_rate' => 90));
+    $agent = $this->createTestAgent(array('control_rate' => 10, 'explore_rate' => 30));
 
     $agent_name = $agent->getTitle();
     $machine_name = $agent->getMachineName();
@@ -137,6 +137,7 @@ class AcquiaLiftWebTest extends DrupalWebTestCase {
             'adaptive',
             'enabled',
             0.1,
+            0.3,
           )
         );
       }
@@ -163,6 +164,7 @@ class AcquiaLiftWebTest extends DrupalWebTestCase {
         'adaptive',
         'enabled',
         0.1,
+        0.3,
       )
     );
     $this->assertQueueItems($expected_queue_items);
@@ -177,7 +179,8 @@ class AcquiaLiftWebTest extends DrupalWebTestCase {
           $agent_name,
           'adaptive',
           'enabled',
-          0.1
+          0.1,
+          0.3,
         )
       )
     );
@@ -195,6 +198,7 @@ class AcquiaLiftWebTest extends DrupalWebTestCase {
         'adaptive',
         'enabled',
         0.1,
+        0.3,
       )
     );
     $this->assertQueueItems($expected_queue_items);
@@ -257,7 +261,8 @@ class AcquiaLiftWebTest extends DrupalWebTestCase {
           $agent->getTitle(),
           $agentData['decision_style'],
           'enabled',
-          0
+          0.1,
+          0.2,
         ),
       ),
       array(
@@ -292,7 +297,8 @@ class AcquiaLiftWebTest extends DrupalWebTestCase {
           $agent->getTitle(),
           $agentData['decision_style'],
           'enabled',
-          0
+          0.1,
+          0.2,
         ),
       ),
       array(
@@ -357,6 +363,7 @@ class AcquiaLiftWebTest extends DrupalWebTestCase {
     $agent = personalize_agent_load_agent($agent->getMachineName(), TRUE);
 
     $agentData = $agent->getData();
+    debug($agentData);
     $expected_queues = array(
       array(
         'method' => 'saveAgent',
@@ -365,7 +372,8 @@ class AcquiaLiftWebTest extends DrupalWebTestCase {
           $agent->getTitle(),
           $agentData['decision_style'],
           'enabled',
-          (100 - $agentData['control_rate']) / 100,
+          ($agentData['control']['control_rate'] / 100),
+          ($agentData['distribution']['explore_rate'] / 100),
         ),
       ),
     );
@@ -458,7 +466,8 @@ class AcquiaLiftWebTest extends DrupalWebTestCase {
             $agent->getTitle(),
             $agentData['decision_style'],
             'enabled',
-            (100 - $agentData['control_rate']) / 100,
+            $agentData['control']['control_rate'] / 100,
+            ($agentData['distribution']['explore_rate'] / 100),
           ),
         );
       }
@@ -534,7 +543,8 @@ class AcquiaLiftWebTest extends DrupalWebTestCase {
             $agent->getTitle(),
             $agentData['decision_style'],
             'enabled',
-            (100 - $agentData['control_rate']) / 100
+            $agentData['control']['control_rate'] / 100,
+            ($agentData['distribution']['explore_rate'] / 100),
           ),
         );
       }
@@ -612,7 +622,8 @@ class AcquiaLiftWebTest extends DrupalWebTestCase {
           $agent->getTitle(),
           'adaptive',
           'enabled',
-          0,
+          0.1,
+          0.2,
         ),
       ),
     );
@@ -691,7 +702,8 @@ class AcquiaLiftWebTest extends DrupalWebTestCase {
           $agent->getTitle(),
           'adaptive',
           'enabled',
-          0,
+          0.1,
+          0.2,
         ),
       ),
     );
@@ -730,7 +742,8 @@ class AcquiaLiftWebTest extends DrupalWebTestCase {
           $agent->getTitle(),
           'adaptive',
           'enabled',
-          0,
+          0.1,
+          0.2,
         ),
       ),
     );
@@ -798,7 +811,8 @@ class AcquiaLiftWebTest extends DrupalWebTestCase {
         $agent_name,
         'adaptive',
         'enabled',
-        0,
+        0.1,
+        0.2,
       )
     );
     $expected_queue_items[] = $queued_agent_item;
@@ -885,7 +899,8 @@ class AcquiaLiftWebTest extends DrupalWebTestCase {
       'name' => $this->randomName(),
       'agent_type' => 'acquia_lift',
       'decision_style' => 'adaptive',
-      'control_rate' => 100,
+      'control_rate' => 10,
+      'explore_rate' => 20,
     );
 
     $data +=  array('machine_name' => personalize_generate_machine_name($data['name'], 'personalize_agent_machine_name_exists'));
@@ -894,7 +909,8 @@ class AcquiaLiftWebTest extends DrupalWebTestCase {
       'agent_basic_info[machine_name]' => $data['machine_name'],
       'agent_basic_info[agent_type]' => $data['agent_type'],
       'agent_basic_info[options][acquia_lift][decision_style]' => $data['decision_style'],
-      'agent_basic_info[options][acquia_lift][control_rate]' => $data['control_rate'],
+      'agent_basic_info[options][acquia_lift][control][control_rate]' => $data['control_rate'],
+      'agent_basic_info[options][acquia_lift][explore_rate]' => $data['explore_rate'],
     );
 
     $this->drupalPost('admin/structure/personalize/add', $edit, $this->getButton('agent'));
@@ -909,7 +925,8 @@ class AcquiaLiftWebTest extends DrupalWebTestCase {
           $data['name'],
           'adaptive',
           'enabled',
-          isset($data['control_rate']) ? (100 - $data['control_rate']) / 100 : 0,
+          isset($data['control']['control_rate']) ? $data['control']['control_rate'] / 100 : .1,
+          isset($data['distribution']['explore_rate']) ? ($data['distribution']['explore_rate'] / 100) : .2,
         )
       )
     );


### PR DESCRIPTION
- Enable access to adjust explore rate
- Adjustments to control rate UI
- Convert control rate to initial intent (no more inversion)
- Set control rate default to .1
- Update tests
