### PR TITLE
Ch 819: editHtml personalize element variation

### DIFF
--- a/acquia_lift.admin.inc
+++ b/acquia_lift.admin.inc
@@ -1672,7 +1672,7 @@ function acquia_lift_page_variation_create($variation_set_name, $option_set, $op
   // Add any missing options before adding the one for this variation.
   for ($j = $next_option; $j < $variation_number; $j++) {
     $option_label = empty($first_os) || !isset($first_os->options[$j]) ? t('Variation #@num', array('@num' => $j)) : $first_os->options[$j]['option_label'];
-    $option_set->options[$j] = array('option_id' => 'variation-' . $j, 'option_label' => $option_label);
+    $option_set->options[$j] = array('option_id' => 'variation-' . $j, 'option_label' => $option_label, 'personalize_elements_content' => '');
   }
   // Now add the option for this variation.
   $option_set->options[$variation_number] = array('option_id' => $new_option_id, 'option_label' => $new_option_label) + $option_info;
@@ -1685,7 +1685,7 @@ function acquia_lift_page_variation_create($variation_set_name, $option_set, $op
   for ($k = $variation_number + 1; $k < $max_variation_number; $k++) {
     if (!isset($option_set->options[$k])) {
       $option_label = empty($first_os) || !isset($first_os->options[$k]) ? t('Variation #@num', array('@num' => $k)) : $first_os->options[$k]['option_label'];
-      $option_set->options[$k] = array('option_id' => 'variation-' . $k, 'option_label' => $option_label);
+      $option_set->options[$k] = array('option_id' => 'variation-' . $k, 'option_label' => $option_label, 'personalize_elements_content' => '');
     }
   }
 
@@ -1705,7 +1705,7 @@ function acquia_lift_page_variation_create($variation_set_name, $option_set, $op
       if (!isset($os->options[$i])) {
         $op_id = 'variation-' . $i;
         $op_label = empty($first_os) || !isset($first_os->options[$i]) ? t('Variation #@num', array('@num' => $i)) : $first_os->options[$i]['option_label'];
-        $os->options[$i] = array('option_id' => $op_id, 'option_label' => $op_label);
+        $os->options[$i] = array('option_id' => $op_id, 'option_label' => $op_label, 'personalize_elements_content' => '');
       }
     }
     personalize_option_set_save($os);

--- a/acquia_lift.admin.inc
+++ b/acquia_lift.admin.inc
@@ -1672,11 +1672,11 @@ function acquia_lift_page_variation_create($variation_set_name, $option_set, $op
   // Add any missing options before adding the one for this variation.
   for ($j = $next_option; $j < $variation_number; $j++) {
     $option_label = empty($first_os) || !isset($first_os->options[$j]) ? t('Variation #@num', array('@num' => $j)) : $first_os->options[$j]['option_label'];
-    $option_set->options[$j] = array('option_id' => 'variation-' . $j, 'option_label' => $option_label, 'personalize_elements_content' => '');
+    $option_set->options[$j] = personalize_elements_get_option_for_variation('variation-' . $j, $option_label);
   }
   // Now add the option for this variation.
   $option_set->options[$variation_number] = array('option_id' => $new_option_id, 'option_label' => $new_option_label) + $option_info;
-  $control_option = array('option_label' => PERSONALIZE_CONTROL_OPTION_LABEL, 'option_id' => PERSONALIZE_CONTROL_OPTION_ID);
+  $control_option = personalize_elements_get_option_for_variation(PERSONALIZE_CONTROL_OPTION_ID, PERSONALIZE_CONTROL_OPTION_LABEL);
   if (!$has_control_option) {
     array_unshift($option_set->options, $control_option);
   }
@@ -1685,7 +1685,7 @@ function acquia_lift_page_variation_create($variation_set_name, $option_set, $op
   for ($k = $variation_number + 1; $k < $max_variation_number; $k++) {
     if (!isset($option_set->options[$k])) {
       $option_label = empty($first_os) || !isset($first_os->options[$k]) ? t('Variation #@num', array('@num' => $k)) : $first_os->options[$k]['option_label'];
-      $option_set->options[$k] = array('option_id' => 'variation-' . $k, 'option_label' => $option_label, 'personalize_elements_content' => '');
+      $option_set->options[$k] = personalize_elements_get_option_for_variation('variation-' . $k, $option_label);
     }
   }
 
@@ -1705,7 +1705,7 @@ function acquia_lift_page_variation_create($variation_set_name, $option_set, $op
       if (!isset($os->options[$i])) {
         $op_id = 'variation-' . $i;
         $op_label = empty($first_os) || !isset($first_os->options[$i]) ? t('Variation #@num', array('@num' => $i)) : $first_os->options[$i]['option_label'];
-        $os->options[$i] = array('option_id' => $op_id, 'option_label' => $op_label, 'personalize_elements_content' => '');
+        $os->options[$i] = personalize_elements_get_option_for_variation($op_id, $op_label);
       }
     }
     personalize_option_set_save($os);

--- a/acquia_lift.module
+++ b/acquia_lift.module
@@ -1869,6 +1869,17 @@ function acquia_lift_help($path, $arg) {
 }
 
 /**
+ * Implements hook_visitor_actions_selector_ignore
+ */
+function acquia_lift_visitor_actions_selector_ignore() {
+  return array(
+    'classes' => array(
+      'acquia-lift-[a-zA-Z0-9\_\-]+',
+    ),
+  );
+}
+
+/**
  * Returns an AJAX command to display a message box.
  *
  * @param $message

--- a/acquia_lift.module
+++ b/acquia_lift.module
@@ -1869,9 +1869,9 @@ function acquia_lift_help($path, $arg) {
 }
 
 /**
- * Implements hook_visitor_actions_selector_ignore
+ * Implements hook_visitor_actions_ui_selector_ignore
  */
-function acquia_lift_visitor_actions_selector_ignore() {
+function acquia_lift_visitor_actions_ui_selector_ignore() {
   return array(
     'classes' => array(
       'acquia-lift-[a-zA-Z0-9\_\-]+',

--- a/css/acquia_lift.dialog.css
+++ b/css/acquia_lift.dialog.css
@@ -22,7 +22,8 @@
   margin-top: 0;
   color: #ffffff;
 }
-.acquia-lift-variation-type-form.visitor-actions-ui-dialog .visitor-actions-ui-dialog-content label {
+.acquia-lift-variation-type-form.visitor-actions-ui-dialog .visitor-actions-ui-dialog-content label,
+.acquia-lift-variation-type-form.visitor-actions-ui-dialog .visitor-actions-ui-dialog-content .description {
   color: #CCCCCC;
   font-weight: normal;
 }

--- a/js/acquia_lift.dom_selector.js
+++ b/js/acquia_lift.dom_selector.js
@@ -12,7 +12,8 @@
   var pluginName = 'DOMSelector',
     indicatorClass = 'acquia-lift-active-element',
     selectorIgnoreClasses = /(messages|contextual-links-[a-zA-Z/-/_])/g;
-    selectorIgnoreId = null;
+    selectorIgnoreId = null,
+    tipIgnoreId = new RegExp(Drupal.settings.visitor_actions.ignoreIds);
 
   defaults = {
       hoverCss: {
@@ -64,7 +65,7 @@
      * @returns {*|HTMLElement}
      */
     getTipContent: function (element) {
-      if (element.hasOwnProperty('id') && element.id.length > 0 && element.id.match(selectorIgnoreId) == null) {
+      if (element.hasOwnProperty('id') && element.id.length > 0 && !tipIgnoreId.test(element.id)) {
         return element.id;
       } else {
         return '&lt;' + element.nodeName.toLowerCase() + '&gt;';

--- a/js/acquia_lift.dom_selector.js
+++ b/js/acquia_lift.dom_selector.js
@@ -11,8 +11,8 @@
    */
   var pluginName = 'DOMSelector',
     indicatorClass = 'acquia-lift-active-element',
-    selectorIgnoreClasses = null,
-    selectorIgnoreId = /^(visitorActionsUI-)|(visitorActionsUIDialog-)|(panels-ipe-)/;
+    selectorIgnoreClasses = new RegExp(Drupal.settings.visitor_actions.ignoreClasses, 'g'),
+    selectorIgnoreId = new RegExp(Drupal.settings.visitor_actions.ignoreIds);
 
   defaults = {
       hoverCss: {

--- a/js/acquia_lift.dom_selector.js
+++ b/js/acquia_lift.dom_selector.js
@@ -11,8 +11,8 @@
    */
   var pluginName = 'DOMSelector',
     indicatorClass = 'acquia-lift-active-element',
-    selectorIgnoreClasses = new RegExp(Drupal.settings.visitor_actions.ignoreClasses, 'g'),
-    selectorIgnoreId = new RegExp(Drupal.settings.visitor_actions.ignoreIds);
+    selectorIgnoreClasses = /(messages|contextual-links-[a-zA-Z/-/_])/g;
+    selectorIgnoreId = null;
 
   defaults = {
       hoverCss: {
@@ -157,6 +157,13 @@
      */
     isWatching: function() {
       return this._watching;
+    },
+
+    /**
+     * Update the watched elements
+     */
+    updateElements: function($updated) {
+      this.$element = $updated;
     },
 
     /**

--- a/js/acquia_lift.page_variations.js
+++ b/js/acquia_lift.page_variations.js
@@ -157,7 +157,8 @@
         if (show) {
           $(this.anchor).addClass(highlightClass);
         } else {
-          $(this.anchor).removeClass(highlightClass);
+          $('.' + highlightClass).removeClass(highlightClass);
+//          $(this.anchor).removeClass(highlightClass);
         }
       },
 

--- a/js/acquia_lift.page_variations.js
+++ b/js/acquia_lift.page_variations.js
@@ -157,8 +157,9 @@
         if (show) {
           $(this.anchor).addClass(highlightClass);
         } else {
+          // Remove the highlight from anywhere (the anchor may have been
+          // changed).
           $('.' + highlightClass).removeClass(highlightClass);
-//          $(this.anchor).removeClass(highlightClass);
         }
       },
 

--- a/js/acquia_lift.page_variations.js
+++ b/js/acquia_lift.page_variations.js
@@ -296,12 +296,18 @@
        */
       formSuccessHandler: function (ajax, response, status) {
         this.parent('formSuccessHandler', ajax, response, status);
-        this.$el.find('[name="selector"]').val(this.model.get('selector'));
+
+        var selector = this.model.get('selector');
+        var type = this.model.get('type');
+        var $input = this.$el.find('[name=personalize_elements_content]');
+        var variationNumber = this.model.get('variationIndex');
+
+        this.$el.find('[name="selector"]').val(selector);
         this.$el.find('[name="pages"]').val(Drupal.settings.visitor_actions.currentPath);
         this.$el.find('[name="agent"]').val(Drupal.settings.personalize.activeCampaign);
-        this.$el.find('[name="variation_number"]').val(this.model.get('variationIndex'));
+        this.$el.find('[name="variation_number"]').val(variationNumber);
         // Call any variation type specific callbacks.
-        Drupal.personalize.executors.personalizeElements.editInContext(this.model.get('type'), this.model.get('selector'), this.$el.find('[name=personalize_elements_content]'));
+        $(document).trigger('acquiaLiftVariationTypeForm', [type, selector, $input]);
       },
 
       /**
@@ -558,6 +564,19 @@
       data: data
     };
     Drupal.ajax.prototype.commands.acquia_lift_page_variation_toggle(Drupal.ajax, response, 200);
+  });
+
+  Drupal.personalize = Drupal.personalize || {};
+  Drupal.personalize.executors = Drupal.personalize.executors || {};
+  Drupal.personalize.executors.personalizeElements = Drupal.personalize.executors.personalizeElements || {};
+  /**
+   * Whenever a variation type form is complete, call the personalize elements
+   * editInContext callbacks.
+   */
+  $(document).on('acquiaLiftVariationTypeForm', function(e, type, selector, $input) {
+    if (Drupal.personalize.executors.personalizeElements.editInContext && typeof Drupal.personalize.executors.personalizeElements.editInContext === 'function') {
+      Drupal.personalize.executors.personalizeElements.editInContext(type, selector, $input);
+    }
   });
 
   }(jQuery, Drupal, Drupal.visitorActions.ui.dialog, Backbone, _));

--- a/js/acquia_lift.page_variations.js
+++ b/js/acquia_lift.page_variations.js
@@ -551,8 +551,42 @@
    */
   Drupal.acquiaLiftPageVariations.personalizeElements = Drupal.acquiaLiftPageVariations.personalizeElements || {};
   Drupal.acquiaLiftPageVariations.personalizeElements.editHtml = {
+    getOuterHtml: function($element) {
+      if ($element.length > 1) {
+        $element = $element.first();
+      }
+      // jQuery doesn't have an outerHTML so we need to clone the child and
+      // give it a parent so that we can call that parent's html function.
+      // This ensures we get only the html of the $selector and not siblings.
+      var $element = $element.clone().wrap('<div>').parent();
+      // Remove any extraneous acquia lift / visitor actions stuff.
+      var removeClasses = new RegExp(Drupal.settings.visitor_actions.ignoreClasses, 'g');
+      var removeId = new RegExp(Drupal.settings.visitor_actions.ignoreIds);
+      var removeTags = 'script';
+
+      // Remove any invalid ids.
+      $element.find('[id]').filter(function() {
+        return removeId.test(this.id);
+      }).removeAttr('id');
+
+      // Remove any classes that are marked for ignore.
+      $element.find('[class]').each(function() {
+        var stripClasses = this.className.match(removeClasses) || [];
+        $(this).removeClass(stripClasses.join(' '));
+        if (this.className.length == 0) {
+          $(this).removeAttr('class');
+        }
+      });
+      // Remove any styling added directly from jQuery.
+      $element.find('[style]').removeAttr('style');
+      // Remove any inappropriate tags
+      $element.find(removeTags).remove();
+
+      // Now return the cleaned up html.
+      return $element.html();
+    },
     editInContext : function(selector, $contentInput) {
-      var editString = Drupal.personalizeElements.editHtml.getOuterHtml($(selector));
+      var editString = this.getOuterHtml($(selector));
       $contentInput.val(editString);
     }
   };

--- a/js/acquia_lift.page_variations.js
+++ b/js/acquia_lift.page_variations.js
@@ -120,9 +120,7 @@
         _.bindAll(this, 'createContextualMenu', 'onElementSelected');
 
         var that = this;
-        this.$watchElements = options.$watchElements;
         this.$el.DOMSelector({
-          $watchElements: this.$watchElements,
           onElementSelect: function (element, selector) {
             that.onElementSelected(element, selector);
           }
@@ -138,6 +136,10 @@
        */
       render: function (model, editMode) {
         if (editMode) {
+          // Must update the watched elements as the page DOM structure can
+          // be changed in between each call.
+          this.$watchElements = getAvailableElements();
+          this.$el.DOMSelector("updateElements", this.$watchElements);
           this.$el.DOMSelector("startWatching");
         } else {
           this.$el.DOMSelector("stopWatching");
@@ -528,14 +530,10 @@
         Drupal.acquiaLiftPageVariations.app.appModel = new Drupal.acquiaLiftPageVariations.models.AppModel();
       }
       if (!Drupal.acquiaLiftPageVariations.app.appView) {
-        var $elements = getAvailableElements();
-        if ($elements.length > 0) {
-          Drupal.acquiaLiftPageVariations.app.appView = new Drupal.acquiaLiftPageVariations.views.AppView({
-            model: Drupal.acquiaLiftPageVariations.app.appModel,
-            $watchElements: $elements,
-            $el: $('body')
-          });
-        }
+        Drupal.acquiaLiftPageVariations.app.appView = new Drupal.acquiaLiftPageVariations.views.AppView({
+          model: Drupal.acquiaLiftPageVariations.app.appModel,
+          $el: $('body')
+        });
       }
       var editVariation = response.data.variationIndex || -1;
       Drupal.acquiaLiftPageVariations.app.appModel.set('variationIndex', editVariation);

--- a/js/acquia_lift.page_variations.js
+++ b/js/acquia_lift.page_variations.js
@@ -124,7 +124,7 @@
         return _(this.filter(function(data) {
           return data.get("completed") == status;
         }));
-      },
+      }
     })
   };
 
@@ -546,6 +546,25 @@
   }
 
   /**
+   * Define editInContext behaviors to define what happens when creating
+   * a particular persaonlize_element page variation in context.
+   */
+  Drupal.acquiaLiftPageVariations.personalizeElements = Drupal.acquiaLiftPageVariations.personalizeElements || {};
+  Drupal.acquiaLiftPageVariations.personalizeElements.editHtml = {
+    editInContext : function(selector, $contentInput) {
+      var editString = Drupal.personalizeElements.editHtml.getOuterHtml($(selector));
+      $contentInput.val(editString);
+    }
+  };
+
+  Drupal.acquiaLiftPageVariations.personalizeElements.editText = {
+    editInContext : function(selector, $contentInput) {
+      var editString = $(selector).text();
+      $contentInput.val(editString);
+    }
+  };
+
+  /**
    * A command to trigger the page element selection process.
    *
    * The response should include a data object with the following keys:
@@ -595,16 +614,15 @@
     Drupal.ajax.prototype.commands.acquia_lift_page_variation_toggle(Drupal.ajax, response, 200);
   });
 
-  Drupal.personalize = Drupal.personalize || {};
-  Drupal.personalize.executors = Drupal.personalize.executors || {};
-  Drupal.personalize.executors.personalizeElements = Drupal.personalize.executors.personalizeElements || {};
   /**
    * Whenever a variation type form is complete, call the personalize elements
    * editInContext callbacks.
    */
   $(document).on('acquiaLiftVariationTypeForm', function(e, type, selector, $input) {
-    if (Drupal.personalize.executors.personalizeElements.editInContext && typeof Drupal.personalize.executors.personalizeElements.editInContext === 'function') {
-      Drupal.personalize.executors.personalizeElements.editInContext(type, selector, $input);
+    if (Drupal.acquiaLiftPageVariations.personalizeElements.hasOwnProperty(type)
+      && Drupal.acquiaLiftPageVariations.personalizeElements[type].hasOwnProperty('editInContext')
+      && typeof Drupal.acquiaLiftPageVariations.personalizeElements[type].editInContext === 'function') {
+      Drupal.acquiaLiftPageVariations.personalizeElements[type].editInContext(selector, $input);
     }
   });
 

--- a/js/acquia_lift.page_variations.js
+++ b/js/acquia_lift.page_variations.js
@@ -299,6 +299,8 @@
         this.$el.find('[name="pages"]').val(Drupal.settings.visitor_actions.currentPath);
         this.$el.find('[name="agent"]').val(Drupal.settings.personalize.activeCampaign);
         this.$el.find('[name="variation_number"]').val(this.model.get('variationIndex'));
+        // Call any variation type specific callbacks.
+        Drupal.personalize.executors.personalizeElements.editInContext(this.model.get('type'), this.model.get('selector'), this.$el.find('[name=personalize_elements_content]'));
       },
 
       /**

--- a/qunit/libraries.html
+++ b/qunit/libraries.html
@@ -32,6 +32,8 @@
     Drupal.settings = Drupal.settings || {};
     Drupal.theme = Drupal.theme || {};
     Drupal.settings.personalize = Drupal.settings.personalize || {};
+    Drupal.settings.visitor_actions = Drupal.settings.visitor_actions || {};
+    Drupal.settings.visitor_actions.ignoreIds = '/(^nowatch)';
 </script>
 
 <script src="../js/acquia_lift.dom_selector.js"></script>

--- a/qunit/page_variations.html
+++ b/qunit/page_variations.html
@@ -12,7 +12,7 @@
     <div class="region-page-top"></div>
     <div id="watch">
         <div id="mousehere">Mouse element</div>
-        <div id="another">Another element</div>
+        <div id="another">Another element with <span class="some-class">a span element inside.</span></div>
     </div>
     <div id="nowatch">No DOM watching allowed here.</div>
 </div>
@@ -30,17 +30,20 @@
 <script src="../../visitor_actions/modules/visitor_actions_ui/js/visitor_actions_ui.selector.js"></script>
 <script src="../../visitor_actions/modules/visitor_actions_ui//js/visitor_actions_ui.dialog.js"></script>
 <script src="/sites/all/libraries/qtip/jquery.qtip-1.0.0-rc3.js"></script>
-<script src="../js/acquia_lift.dom_selector.js"></script>
-<script src="../js/acquia_lift.messagebox.js"></script>
-
 
 <script type="text/javascript">
     var Drupal = Drupal || {};
     Drupal.behaviors = Drupal.behaviors || {};
     Drupal.settings = Drupal.settings || {};
     Drupal.theme = Drupal.theme || {};
+    Drupal.settings.acquia_lift = Drupal.settings.acquia_lift || {};
+    Drupal.settings.acquia_lift.dom_selector_ignore = 'region-page-top';
     Drupal.settings.personalize = Drupal.settings.personalize || {};
+    Drupal.settings.visitor_actions = Drupal.settings.visitor_actions || {};
+    Drupal.settings.visitor_actions.ignoreIds = '/(^nowatch)';
 </script>
+<script src="../js/acquia_lift.dom_selector.js"></script>
+<script src="../js/acquia_lift.messagebox.js"></script>
 
 <script src="../js/acquia_lift.page_variations.js"></script>
 <script src="page_variations.tests.js"></script>

--- a/qunit/page_variations.tests.js
+++ b/qunit/page_variations.tests.js
@@ -120,13 +120,59 @@ QUnit.asyncTest('Contextual menu view', function (assert) {
   var dialogTitle = Drupal.theme.acquiaLiftPageVariationsMenuTitle({elementType: 'DIV'});
   assert.equal(dialogHtml.search(dialogTitle), 0, 'Dialog title created and at start of content.');
   assert.ok(view.list instanceof Drupal.acquiaLiftPageVariations.views.PageVariationMenuListView, 'Dialog list component is a PageVariationMenuListView.');
-  assert.equal($dialog.find('.visitor-actions-ui-dialog-content ul.acquia-lift-page-variation-list li').length, 4, 'Dialog list is rendered with one list item per variation type.');
+  assert.equal($dialog.find('.visitor-actions-ui-dialog-content ul.acquia-lift-page-variation-list li').length, 5, 'Dialog list is rendered with one list item per variation type.');
 
   QUnit.stop();
   // Callback for individual type click.
   Backbone.on('acquiaLiftPageVariationType', function(e) {
     QUnit.start();
     assert.equal(e.data.anchor.id, 'mousehere', 'Variation type selected triggered with correct anchor element.');
+    assert.equal(e.data.selector, anchorSelector, 'Variation type selected triggered with correct anchor element.');
+    assert.equal(e.data.id, 'addCss', 'Variation type selected with correct variation type id.');
+    assert.equal(e.data.name, 'Add CSS class', 'Variation type selected with correction variation type name.');
+    Backbone.off('acquiaLiftPageVariationType');
+    QUnit.stop();
+    // Give the dialog time to close.
+    setTimeout(function() {
+      QUnit.start();
+      $dialog = jQuery('#' + id + '-dialog');
+      assert.equal($dialog.length, 0, 'Contextual menu view has been removed.');
+    }, 1000)
+  })
+  $dialog.find('.visitor-actions-ui-dialog-content ul.acquia-lift-page-variation-list li:first-child a').trigger('click');
+})
+
+QUnit.asyncTest('Contextual menu limited by children node types', function (assert) {
+  QUnit.start();
+  expect(11);
+  var anchorSelector = '#another';
+  var $anchor = jQuery(anchorSelector);
+  var id = 'testing-' + new Date().getTime();
+  var model = new Drupal.visitorActions.ui.dialog.models.DialogModel({
+    selector: anchorSelector,
+    id: id
+  });
+  var view = new Drupal.acquiaLiftPageVariations.views.PageVariationMenuView({
+    el: $anchor[0],
+    model: model
+  });
+  model.set('active', true);
+  var $dialog = jQuery('#' + id + '-dialog');
+  assert.equal($dialog.length, 1, 'Dialog created with specified id.');
+  assert.ok($dialog.hasClass(view.className), 'Dialog created with view class.');
+  assert.equal($dialog.find('.visitor-actions-ui-dialog-content').length, 1, 'Dialog content created.');
+
+  var dialogHtml = $dialog.find('.visitor-actions-ui-dialog-content').html();
+  var dialogTitle = Drupal.theme.acquiaLiftPageVariationsMenuTitle({elementType: 'DIV'});
+  assert.equal(dialogHtml.search(dialogTitle), 0, 'Dialog title created and at start of content.');
+  assert.ok(view.list instanceof Drupal.acquiaLiftPageVariations.views.PageVariationMenuListView, 'Dialog list component is a PageVariationMenuListView.');
+  assert.equal($dialog.find('.visitor-actions-ui-dialog-content ul.acquia-lift-page-variation-list li').length, 4, 'Dialog list is rendered with one list item per variation type.');
+
+  QUnit.stop();
+  // Callback for individual type click.
+  Backbone.on('acquiaLiftPageVariationType', function(e) {
+    QUnit.start();
+    assert.equal(e.data.anchor.id, 'another', 'Variation type selected triggered with correct anchor element.');
     assert.equal(e.data.selector, anchorSelector, 'Variation type selected triggered with correct anchor element.');
     assert.equal(e.data.id, 'addCss', 'Variation type selected with correct variation type id.');
     assert.equal(e.data.name, 'Add CSS class', 'Variation type selected with correction variation type name.');

--- a/qunit/page_variations.tests.js
+++ b/qunit/page_variations.tests.js
@@ -32,10 +32,22 @@ QUnit.module("Acquia Lift page variation views", {
     Drupal.settings.basePath = '/';
     Drupal.settings.personalize_elements = Drupal.settings.personalize_elements || {};
     Drupal.settings.personalize_elements.contextualVariationTypes = Drupal.settings.personalize_elements.contextualVariationTypes || {
-      'addCss': 'Add CSS class',
-      'replaceHTML': 'Replace HTML',
-      'appendHTML': 'Append HTML',
-      'prependHTML': 'Prepend HTML'
+      'addCss': {
+        name: 'Add CSS class'
+      },
+      'editHtml': {
+        name: 'Edit HTML'
+      },
+      'editText': {
+        name: 'Edit text',
+        limitByChildrenType: 3
+      },
+      'appendHtml': {
+        name: 'Append HTML'
+      },
+      'prependHtml': {
+        name: 'Prepend HTML'
+      }
     };
     Drupal.settings.visitor_actions = Drupal.settings.visitor_actions || {};
     Drupal.settings.visitor_actions.currentPath = 'node';

--- a/qunit/page_variations.tests.js
+++ b/qunit/page_variations.tests.js
@@ -68,6 +68,7 @@ QUnit.test('Application view', function (assert) {
     anchor: $anchor[0]
   }
   // @todo: this will throw errors because we are not coming from a Drupal path and therefore there is no existing base theme.
+  // This prevents any additional tests being run on the variation type form dialog.
   appView.createVariationTypeDialog({data: data});
   assert.equal(appView.variationTypeFormModel.get('selector'), data.selector, 'Variation type form model selector set successfully.');
   assert.ok(appView.variationTypeFormModel.get('id'), 'Variation type form model ID set successfully.');

--- a/tests/acquia_lift.test
+++ b/tests/acquia_lift.test
@@ -137,7 +137,6 @@ class AcquiaLiftWebTest extends DrupalWebTestCase {
       array(
         'option_id' => 'variation-1',
         'option_label' => 'Variation #1',
-        'personalize_elements_content' => '',
       ),
       array(
         'option_id' => 'variation-2',
@@ -229,7 +228,6 @@ class AcquiaLiftWebTest extends DrupalWebTestCase {
       array(
         'option_id' => 'variation-2',
         'option_label' => 'Variation #2',
-        'personalize_elements_content' => '',
       ),
       array(
         'option_id' => 'variation-3',
@@ -244,7 +242,6 @@ class AcquiaLiftWebTest extends DrupalWebTestCase {
       array(
         'option_id' => 'variation-5',
         'option_label' => 'Variation #5',
-        'personalize_elements_content' => '',
       ),
     );
     $this->assertEqual($expected_options_os1, $option_sets[1]->options);
@@ -256,7 +253,6 @@ class AcquiaLiftWebTest extends DrupalWebTestCase {
       array(
         'option_id' => 'variation-1',
         'option_label' => 'Variation #1',
-        'personalize_elements_content' => '',
       ),
       array(
         'option_id' => 'variation-2',
@@ -266,7 +262,6 @@ class AcquiaLiftWebTest extends DrupalWebTestCase {
       array(
         'option_id' => 'variation-3',
         'option_label' => 'three',
-        'personalize_elements_content' => '',
       ),
       array(
         'option_id' => 'variation-4',
@@ -294,22 +289,18 @@ class AcquiaLiftWebTest extends DrupalWebTestCase {
       array(
         'option_id' => 'variation-2',
         'option_label' => 'Variation #2',
-        'personalize_elements_content' => '',
       ),
       array(
         'option_id' => 'variation-3',
         'option_label' => 'three',
-        'personalize_elements_content' => '',
       ),
       array(
         'option_id' => 'variation-4',
         'option_label' => 'Variation #4',
-        'personalize_elements_content' => '',
       ),
       array(
         'option_id' => 'variation-5',
         'option_label' => 'Variation #5',
-        'personalize_elements_content' => '',
       ),
     );
     $this->assertEqual($expected_options_os3, $option_sets[3]->options);

--- a/tests/acquia_lift.test
+++ b/tests/acquia_lift.test
@@ -137,6 +137,7 @@ class AcquiaLiftWebTest extends DrupalWebTestCase {
       array(
         'option_id' => 'variation-1',
         'option_label' => 'Variation #1',
+        'personalize_elements_content' => '',
       ),
       array(
         'option_id' => 'variation-2',
@@ -162,8 +163,6 @@ class AcquiaLiftWebTest extends DrupalWebTestCase {
     $admin_user = $this->drupalCreateUser(array('access administration pages', 'manage personalized content', 'administer blocks'));
     $this->drupalLogin($admin_user);
 
-    // Create some custom blocks to use as variations.
-    $deltas = $this->createCustomBlocks(10);
     // Create a new agent via the UI.
     $agent_name = $this->randomName();
     $machine_name = personalize_generate_machine_name($agent_name, 'personalize_agent_machine_name_exists');
@@ -173,73 +172,41 @@ class AcquiaLiftWebTest extends DrupalWebTestCase {
       'agent_basic_info[agent_type]' => 'test_agent',
     );
     $this->drupalPost('admin/structure/personalize/add', $edit, $this->getButton('agent'));
-    $os = array(
-      'agent' => $agent_name,
-      'plugin' => 'block',
-      'executor' => 'show',
-      'options' => array(
-        array('option_id' => PERSONALIZE_CONTROL_OPTION_ID, 'option_label' => PERSONALIZE_CONTROL_OPTION_LABEL, 'bid' => array_shift($deltas))
-      ),
-      'data' => array(
-        'block_title' => 'My personalized block'
-      )
-    );
-    $option_set = (object) $os;
-    $var_num = acquia_lift_page_variation_create('first_variation_set', $option_set, array('bid' => array_shift($deltas)));
+
+    $option_set = personalize_elements_get_option_set_for_variation('option-1', $agent_name, '#selector1', 'addCss', 'page1');
+    $var_num = acquia_lift_page_variation_create('first_variation_set', $option_set, array('personalize_elements_content' => 'test-class'));
     $this->assertEqual(1, $var_num);
 
-    // Now create another block-based option set and use it for the second variation.
-    $os2 = array(
-      'agent' => $agent_name,
-      'plugin' => 'block',
-      'executor' => 'show',
-      'options' => array(
-        array('option_id' => PERSONALIZE_CONTROL_OPTION_ID, 'option_label' => PERSONALIZE_CONTROL_OPTION_LABEL, 'bid' => array_shift($deltas))
-      ),
-      'data' => array(
-        'block_title' => 'My personalized block'
-      )
-    );
-    $option_set_2 = (object) $os2;
-    $var_num = acquia_lift_page_variation_create('first_variation_set', $option_set_2, array('bid' => array_shift($deltas)));
+    // Now create another option set and use it for the second variation.
+    $option_set_2 = personalize_elements_get_option_set_for_variation('option-2', $agent_name, '#selector2', 'editHtml', 'page1');
+    $var_num = acquia_lift_page_variation_create('first_variation_set', $option_set_2, array('personalize_elements_content' => '<p>some html</p>'));
     $this->assertEqual(2, $var_num);
 
     // Now use the first option set for variation 3.
     $os_1 = personalize_option_set_load(1, TRUE);
-    $var_num = acquia_lift_page_variation_create('first_variation_set', $os_1, array('bid' => array_shift($deltas)));
+    $var_num = acquia_lift_page_variation_create('first_variation_set', $os_1, array('personalize_elements_content' => 'another-test-class'));
     $this->assertEqual(3, $var_num);
 
-    // Now add a different option to both blocks for variation 4.
+    // Now add a different option to both for variation 4.
     $os_1 = personalize_option_set_load(1, TRUE);
-    $var_num = acquia_lift_page_variation_create('first_variation_set', $os_1, array('bid' => array_shift($deltas)));
+    $var_num = acquia_lift_page_variation_create('first_variation_set', $os_1, array('personalize_elements_content' => 'third-test-class'));
     $this->assertEqual(4, $var_num);
 
     // Rename the third variation to test if the new names persist across changes.
     acquia_lift_page_variation_rename('first_variation_set', $agent_name, 3, 'three');
 
     $os_2 = personalize_option_set_load(2, TRUE);
-    $var_num = acquia_lift_page_variation_create('first_variation_set', $os_2, array('bid' => array_shift($deltas)), 4);
+    $var_num = acquia_lift_page_variation_create('first_variation_set', $os_2, array('personalize_elements_content' => '<p>some other html</p>'), 4);
     $this->assertEqual(4, $var_num);
 
     // Try to create variation 6, it should correct it to 5.
-    $var_num = acquia_lift_page_variation_create('first_variation_set', $os_2, array('bid' => array_shift($deltas)), 6);
+    $var_num = acquia_lift_page_variation_create('first_variation_set', $os_2, array('personalize_elements_content' => '<p>third html</p>'), 6);
     $this->assertEqual(5, $var_num);
 
-    // Create another block-based option set and add it to variation 1. (We need to
+    // Create another option set and add it to variation 1. (We need to
     // make sure an option gets created for each subsequent variation.)
-    $os3 = array(
-      'agent' => $agent_name,
-      'plugin' => 'block',
-      'executor' => 'show',
-      'options' => array(
-        array('option_id' => PERSONALIZE_CONTROL_OPTION_ID, 'option_label' => PERSONALIZE_CONTROL_OPTION_LABEL, 'bid' => array_shift($deltas))
-      ),
-      'data' => array(
-        'block_title' => 'My personalized block'
-      )
-    );
-    $option_set_3 = (object) $os3;
-    $var_num = acquia_lift_page_variation_create('first_variation_set', $option_set_3, array('bid' => array_shift($deltas)), 1);
+    $option_set_3 = personalize_elements_get_option_set_for_variation('option-3', $agent_name, '#selector3', 'editText', 'page1');
+    $var_num = acquia_lift_page_variation_create('first_variation_set', $option_set_3, array('personalize_elements_content' => 'edited text'), 1);
     $this->assertEqual(1, $var_num);
 
     $this->resetAll();
@@ -253,30 +220,31 @@ class AcquiaLiftWebTest extends DrupalWebTestCase {
       array(
         'option_id' => PERSONALIZE_CONTROL_OPTION_ID,
         'option_label' => PERSONALIZE_CONTROL_OPTION_LABEL,
-        'bid' => 'block_delta_1',
       ),
       array(
         'option_id' => 'variation-1',
         'option_label' => 'Variation #1',
-        'bid' => 'block_delta_2'
+        'personalize_elements_content' => 'test-class'
       ),
       array(
         'option_id' => 'variation-2',
         'option_label' => 'Variation #2',
+        'personalize_elements_content' => '',
       ),
       array(
         'option_id' => 'variation-3',
         'option_label' => 'three',
-        'bid' => 'block_delta_5'
+        'personalize_elements_content' => 'another-test-class',
       ),
       array(
         'option_id' => 'variation-4',
         'option_label' => 'Variation #4',
-        'bid' => 'block_delta_6'
+        'personalize_elements_content' => 'third-test-class',
       ),
       array(
         'option_id' => 'variation-5',
         'option_label' => 'Variation #5',
+        'personalize_elements_content' => '',
       ),
     );
     $this->assertEqual($expected_options_os1, $option_sets[1]->options);
@@ -284,30 +252,31 @@ class AcquiaLiftWebTest extends DrupalWebTestCase {
       array(
         'option_id' => PERSONALIZE_CONTROL_OPTION_ID,
         'option_label' => PERSONALIZE_CONTROL_OPTION_LABEL,
-        'bid' => 'block_delta_3',
       ),
       array(
         'option_id' => 'variation-1',
         'option_label' => 'Variation #1',
+        'personalize_elements_content' => '',
       ),
       array(
         'option_id' => 'variation-2',
         'option_label' => 'Variation #2',
-        'bid' => 'block_delta_4'
+        'personalize_elements_content' => '<p>some html</p>',
       ),
       array(
         'option_id' => 'variation-3',
         'option_label' => 'three',
+        'personalize_elements_content' => '',
       ),
       array(
         'option_id' => 'variation-4',
         'option_label' => 'Variation #4',
-        'bid' => 'block_delta_7'
+        'personalize_elements_content' => '<p>some other html</p>',
       ),
       array(
         'option_id' => 'variation-5',
         'option_label' => 'Variation #5',
-        'bid' => 'block_delta_8'
+        'personalize_elements_content' => '<p>third html</p>',
       ),
     );
     $this->assertEqual($expected_options_os2, $option_sets[2]->options);
@@ -315,29 +284,32 @@ class AcquiaLiftWebTest extends DrupalWebTestCase {
       array(
         'option_id' => PERSONALIZE_CONTROL_OPTION_ID,
         'option_label' => PERSONALIZE_CONTROL_OPTION_LABEL,
-        'bid' => 'block_delta_9',
 
       ),
       array(
         'option_id' => 'variation-1',
         'option_label' => 'Variation #1',
-        'bid' => 'block_delta_10',
+        'personalize_elements_content' => 'edited text',
       ),
       array(
         'option_id' => 'variation-2',
         'option_label' => 'Variation #2',
+        'personalize_elements_content' => '',
       ),
       array(
         'option_id' => 'variation-3',
         'option_label' => 'three',
+        'personalize_elements_content' => '',
       ),
       array(
         'option_id' => 'variation-4',
         'option_label' => 'Variation #4',
+        'personalize_elements_content' => '',
       ),
       array(
         'option_id' => 'variation-5',
         'option_label' => 'Variation #5',
+        'personalize_elements_content' => '',
       ),
     );
     $this->assertEqual($expected_options_os3, $option_sets[3]->options);


### PR DESCRIPTION
Add an additional trigger when variation type form loads to call the personalize elements callback for editInContext.
Minor CSS changes so that you can see descriptions in the variation type form.
