### PR TITLE
Prevent scroll wiggle when the viewport is large enough to contain all campaigns in the list.

### DIFF
--- a/css/acquia_lift.navbar.css
+++ b/css/acquia_lift.navbar.css
@@ -73,6 +73,7 @@
 #navbar-administration .navbar-tray-acquia-lift.navbar-tray-horizontal .acquia-lift-scrollable {
   max-height: 70vh;
   overflow-y: auto;
+  padding-bottom: .3em;
 }
 #navbar-administration .navbar-tray-acquia-lift.navbar-tray-horizontal .menu ul ul {
   border-bottom: 1px solid #dddddd;


### PR DESCRIPTION
As mentioned by @lkhaas, a bit of padding seems to do the trick.
