### PR TITLE
CH-950 Added event listeners for personalizeDecision and sentGoalToAgent

### DIFF
--- a/acquia_lift_profiles/js/acquia_lift_profiles.js
+++ b/acquia_lift_profiles/js/acquia_lift_profiles.js
@@ -321,6 +321,18 @@ var _tcwq = _tcwq || [];
       'specialEvents': {
         'user_login': pushCaptureEmail,
         'user_register': pushCaptureEmail
+      },
+
+      /**
+       * Helper function to reset variables during tests.
+       */
+      'resetAll' : function() {
+        processedListeners = {};
+        initialized = false;
+        initializing = false;
+        agentNameToLabel = {};
+        $(document).unbind('personalizeDecision', this["processPersonalizeDecision"]);
+        $(document).unbind('sentGoalToAgent', this["processSentGoalToAgent"]);
       }
     }
   })();

--- a/acquia_lift_profiles/js/acquia_lift_profiles.js
+++ b/acquia_lift_profiles/js/acquia_lift_profiles.js
@@ -143,20 +143,20 @@ var _tcwq = _tcwq || [];
 
     // Keeps track of processed listeners so we don't subscribe them more than once.
     var processedListeners = {}, initialized = false, initializing = false;
-    var agentNameToTitle = {};
+    var agentNameToLabel = {};
 
     /**
-     * Returns the agent tile (label) for the given agent name.
-     * If there is no title then the agent name is returned.
+     * Returns the agent label for the given agent name.
+     * If there is no label then the agent name is returned.
      *
      * @param agent_name
      */
-    function getAgentTitle( agent_name ) {
-      var agent_title = agent_name;
-      if ( agentNameToTitle[agent_name] ) {
-        agent_title = agentNameToTitle[agent_name];
+    function getAgentLabel( agent_name ) {
+      var agent_label = agent_name;
+      if ( agentNameToLabel[agent_name] ) {
+        agent_label = agentNameToLabel[agent_name];
       }
-      return agent_title;
+      return agent_label;
     }
 
     return {
@@ -164,13 +164,14 @@ var _tcwq = _tcwq || [];
         if (initialized || initializing) {
           return;
         }
+
         initializing = true;
         if ( settings.personalize && settings.personalize.agent_map ) {
           var agent_map = settings.personalize.agent_map;
           for (var agent_name in agent_map) {
             if (agent_map.hasOwnProperty(agent_name)) {
-              if (agent_map[agent_name].title) {
-                agentNameToTitle[agent_name] = agent_map[agent_name].title;
+              if (agent_map[agent_name].label) {
+                agentNameToLabel[agent_name] = agent_map[agent_name].label;
               }
             }
           }
@@ -283,12 +284,12 @@ var _tcwq = _tcwq || [];
           decision = 'Control';
         }
 
-        _tcaq.push(['capture', 'Campaign Action', {'campaignid':agent_name, 'campaignname':getAgentTitle(agent_name), 'offerid': decision, 'actionName':decision, 'evalSegments': true } ]);
+        _tcaq.push(['capture', 'Campaign Action', {'campaignid':agent_name, 'campaignname':getAgentLabel(agent_name), 'offerid': decision, 'actionName':decision, 'evalSegments': true } ]);
 
       },
 
       'processSentGoalToAgent':function(e, agent_name, goal_name, goal_value) {
-        _tcaq.push(['capture', goal_name, {'campaignid':agent_name, 'campaignname':getAgentTitle(agent_name), 'evalSegments': true}]);
+        _tcaq.push(['capture', goal_name, {'campaignid':agent_name, 'campaignname':getAgentLabel(agent_name), 'evalSegments': true}]);
       },
       /**
        * Add an action listener for client-side goal events.
@@ -323,6 +324,7 @@ var _tcwq = _tcwq || [];
       }
     }
   })();
+
 
   /**
    * Goes through the server-side actions and calls the appropriate function for

--- a/acquia_lift_profiles/js/acquia_lift_profiles.js
+++ b/acquia_lift_profiles/js/acquia_lift_profiles.js
@@ -143,6 +143,21 @@ var _tcwq = _tcwq || [];
 
     // Keeps track of processed listeners so we don't subscribe them more than once.
     var processedListeners = {}, initialized = false, initializing = false;
+    var agentNameToTitle = {};
+
+    /**
+     * Returns the agent tile (label) for the given agent name.
+     * If there is no title then the agent name is returned.
+     *
+     * @param agent_name
+     */
+    function getAgentTitle( agent_name ) {
+      var agent_title = agent_name;
+      if ( agentNameToTitle[agent_name] ) {
+        agent_title = agentNameToTitle[agent_name];
+      }
+      return agent_title;
+    }
 
     return {
       'init': function(settings) {
@@ -150,6 +165,16 @@ var _tcwq = _tcwq || [];
           return;
         }
         initializing = true;
+        if ( settings.personalize && settings.personalize.agent_map ) {
+          var agent_map = settings.personalize.agent_map;
+          for (var agent_name in agent_map) {
+            if (agent_map.hasOwnProperty(agent_name)) {
+              if (agent_map[agent_name].title) {
+                agentNameToTitle[agent_name] = agent_map[agent_name].title;
+              }
+            }
+          }
+        }
         var mappings = settings.acquia_lift_profiles.udfMappings, context_separator = settings.acquia_lift_profiles.udfMappingContextSeparator, plugins = {}, udfValues = {}, reverseMapping = {};
         for(var type in mappings) {
           if (mappings.hasOwnProperty(type)) {
@@ -213,6 +238,8 @@ var _tcwq = _tcwq || [];
 
           initialized = true;
         };
+        $(document).bind('personalizeDecision', this["processPersonalizeDecision"]);
+        $(document).bind('sentGoalToAgent', this["processSentGoalToAgent"]);
         Drupal.personalize.getVisitorContexts(plugins, callback);
       },
       'getTrackingID': function () {
@@ -249,6 +276,19 @@ var _tcwq = _tcwq || [];
         if (typeof this.specialEvents[eventName] == 'function') {
           this.specialEvents[eventName].call(this, settings.acquia_lift_profiles, context);
         }
+      },
+
+      'processPersonalizeDecision':function(e, $option_set, decision, osid, agent_name) {
+        if (decision == 'control-variation') {
+          decision = 'Control';
+        }
+
+        _tcaq.push(['capture', 'Campaign Action', {'campaignid':agent_name, 'campaignname':getAgentTitle(agent_name), 'offerid': decision, 'actionName':decision, 'evalSegments': true } ]);
+
+      },
+
+      'processSentGoalToAgent':function(e, agent_name, goal_name, goal_value) {
+        _tcaq.push(['capture', goal_name, {'campaignid':agent_name, 'campaignname':getAgentTitle(agent_name), 'evalSegments': true}]);
       },
       /**
        * Add an action listener for client-side goal events.

--- a/acquia_lift_profiles/qunit/tests.js
+++ b/acquia_lift_profiles/qunit/tests.js
@@ -205,7 +205,7 @@ QUnit.asyncTest( "personalize decision event", function( assert ) {
           'cache_decisions': false,
           'enabled_contexts': [],
           'type': 'test_agent',
-          'title' : 'Test Agent'
+          'label' : 'Test Agent'
         }
       }
     }

--- a/acquia_lift_profiles/qunit/tests.js
+++ b/acquia_lift_profiles/qunit/tests.js
@@ -84,8 +84,8 @@ QUnit.module("Acquia Lift Profiles", {
   }
 });
 
-QUnit.asyncTest( "init test", function( assert ) {
-  expect(5);
+QUnit.asyncTest( "init test and personalize events", function( assert ) {
+  expect(14);
   _tcaq = {
     'push':function(stf) {
       console.log(stf);
@@ -94,7 +94,7 @@ QUnit.asyncTest( "init test", function( assert ) {
       assert.equal( stf[2].person_udf1, "some-value", 'value correctly assigned from context' );
       assert.equal( stf[2].person_udf2, "some-other-value", 'value correctly assigned from promise based context' );
       assert.equal( stf[2].person_udf3, "some-other-value", 'same  value correctly assigned to a second UDF' );
-      QUnit.start();
+
     }
   };
   var settings = {
@@ -108,7 +108,18 @@ QUnit.asyncTest( "init test", function( assert ) {
         }
       },
       udfMappingContextSeparator: '__'
-    }
+    },
+    personalize : {
+      agent_map : {
+        'my-agent': {
+          'active': 1,
+          'cache_decisions': false,
+          'enabled_contexts': [],
+          'type': 'test_agent',
+          'label' : 'Test Agent'
+        }
+      }
+    }    
   };
 
   // We need to mock the getVisitorContexts() method as this is called by the
@@ -127,6 +138,32 @@ QUnit.asyncTest( "init test", function( assert ) {
     callback.call(null, values);
   };
   Drupal.acquia_lift_profiles.init(settings);
+  
+  _tcaq = {
+    'push':function(stf) {
+      console.log(stf);
+      assert.equal( stf[0], 'capture',  'capture received');
+      assert.equal( stf[1], 'Campaign Action',  'capture view is of type campaign action');
+      assert.equal( stf[2].campaignid, "my-agent", 'value correctly assigned from event' );
+      assert.equal( stf[2].campaignname, "Test Agent", 'value correctly assigned from event' );
+      assert.equal( stf[2].actionName, "test_decision", 'value correctly assigned from event' );
+    }
+  };
+  $(document).trigger("personalizeDecision", [{}, "test_decision", "test_osid", "my-agent" ]);
+
+
+  _tcaq = {
+    'push':function(stf) {
+      console.log(stf);
+      assert.equal( stf[0], 'capture',  'capture received');
+      assert.equal( stf[1], 'goal-event',  'capture view is of type goal-event');
+      assert.equal( stf[2].campaignid, "my-agent", 'value correctly assigned from event' );
+      assert.equal( stf[2].campaignname, "Test Agent", 'value correctly assigned from event' );
+      QUnit.start();
+    }
+  };
+  $(document).trigger("sentGoalToAgent", ["my-agent", "goal-event", "goal-value"]);
+  
 });
 
 
@@ -161,72 +198,3 @@ QUnit.test("get context values with cache", function( assert ) {
   assert.equal(contextResult['segment1'], 1, 'Segment1 has value 1');
   assert.equal(contextResult['segment2'], 1, 'Segment2 has value 1');
 });
-
-QUnit.asyncTest( "personalize decision event", function( assert ) {
-  expect(10);
-  var personalizeDecisionPushCount = 0;
-  _tcaq = {
-    'push':function(stf) {
-      console.log(stf);
-      if ( personalizeDecisionPushCount == 0 ) {
-        assert.equal( stf[0], 'captureView',  'capture view received');
-        assert.equal( stf[1], 'Content View',  'capture view is of type content view');
-        assert.equal( stf[2].person_udf1, "some-value", 'value correctly assigned from context' );
-        assert.equal( stf[2].person_udf2, "some-other-value", 'value correctly assigned from promise based context' );
-        assert.equal( stf[2].person_udf3, "some-other-value", 'same  value correctly assigned to a second UDF' );
-        QUnit.start();
-      }
-      else {
-        assert.equal( stf[0], 'capture',  'capture view received');
-        assert.equal( stf[1], 'Campaign Action',  'capture view is of type campaign action');
-        assert.equal( stf[2].campaignid, "my-agent", 'value correctly assigned from event' );
-        assert.equal( stf[2].campaignname, "Test Agent", 'value correctly assigned from event' );
-        assert.equal( stf[2].actionName, "test_decision", 'value correctly assigned from event' );
-      }
-      personalizeDecisionPushCount++;
-    }
-  };
-  var settings = {
-    acquia_lift_profiles: {
-      udfMappings: {
-        person: {
-          person_udf1: "my_first_plugin__some-context",
-          person_udf2: "my_promise_plugin__some-other-context",
-          // Test that another UDF can be mapped to the same context.
-          person_udf3: "my_promise_plugin__some-other-context"
-        }
-      },
-      udfMappingContextSeparator: '__'
-    },
-    personalize : {
-      agent_map : {
-        'my-agent': {
-          'active': 1,
-          'cache_decisions': false,
-          'enabled_contexts': [],
-          'type': 'test_agent',
-          'label' : 'Test Agent'
-        }
-      }
-    }
-  };
-
-  // We need to mock the getVisitorContexts() method as this is called by the
-  // init method, which we're testing here. We just need to make it call the
-  // callback that will be passed into it with the values for the contexts
-  // specified.
-  Drupal.personalize.getVisitorContexts = function(plugins, callback) {
-    var values = {
-      'my_first_plugin': {
-        'some-context': 'some-value'
-      },
-      'my_promise_plugin': {
-        'some-other-context': 'some-other-value'
-      }
-    };
-    callback.call(null, values);
-  };
-  Drupal.acquia_lift_profiles.init(settings);
-  $(document).trigger("personalizeDecision", [{}, "test_decision", "test_osid", "my-agent" ]);
-});
-

--- a/acquia_lift_profiles/qunit/tests.js
+++ b/acquia_lift_profiles/qunit/tests.js
@@ -233,3 +233,71 @@ QUnit.asyncTest( "personalize decision event", function( assert ) {
   $(document).trigger("personalizeDecision", [{}, "test_decision", "test_osid", "my-agent" ]);
 });
 
+QUnit.asyncTest( "sent goal to agent event", function( assert ) {
+  expect(9);
+  Drupal.acquia_lift_profiles.resetAll();
+  var personalizeDecisionPushCount = 0;
+  _tcaq = {
+    'push':function(stf) {
+      console.log(stf);
+      if ( personalizeDecisionPushCount == 0 ) {
+        assert.equal( stf[0], 'captureView',  'capture view received');
+        assert.equal( stf[1], 'Content View',  'capture view is of type content view');
+        assert.equal( stf[2].person_udf1, "some-value", 'value correctly assigned from context' );
+        assert.equal( stf[2].person_udf2, "some-other-value", 'value correctly assigned from promise based context' );
+        assert.equal( stf[2].person_udf3, "some-other-value", 'same  value correctly assigned to a second UDF' );
+
+      }
+      else {
+        assert.equal( stf[0], 'capture',  'capture received');
+        assert.equal( stf[1], 'goal-event',  'capture view is of type goal-event');
+        assert.equal( stf[2].campaignid, "my-agent", 'value correctly assigned from event' );
+        assert.equal( stf[2].campaignname, "Test Agent", 'value correctly assigned from event' );
+        QUnit.start();
+      }
+      personalizeDecisionPushCount++;
+    }
+  };
+  var settings = {
+    acquia_lift_profiles: {
+      udfMappings: {
+        person: {
+          person_udf1: "my_first_plugin__some-context",
+          person_udf2: "my_promise_plugin__some-other-context",
+          // Test that another UDF can be mapped to the same context.
+          person_udf3: "my_promise_plugin__some-other-context"
+        }
+      },
+      udfMappingContextSeparator: '__'
+    },
+    personalize : {
+      agent_map : {
+        'my-agent': {
+          'active': 1,
+          'cache_decisions': false,
+          'enabled_contexts': [],
+          'type': 'test_agent',
+          'label' : 'Test Agent'
+        }
+      }
+    }
+  };
+
+  // We need to mock the getVisitorContexts() method as this is called by the
+  // init method, which we're testing here. We just need to make it call the
+  // callback that will be passed into it with the values for the contexts
+  // specified.
+  Drupal.personalize.getVisitorContexts = function(plugins, callback) {
+    var values = {
+      'my_first_plugin': {
+        'some-context': 'some-value'
+      },
+      'my_promise_plugin': {
+        'some-other-context': 'some-other-value'
+      }
+    };
+    callback.call(null, values);
+  };
+  Drupal.acquia_lift_profiles.init(settings);
+  $(document).trigger("sentGoalToAgent", ["my-agent", "goal-event", "goal-value"]);
+});

--- a/acquia_lift_profiles/qunit/tests.js
+++ b/acquia_lift_profiles/qunit/tests.js
@@ -161,3 +161,72 @@ QUnit.test("get context values with cache", function( assert ) {
   assert.equal(contextResult['segment1'], 1, 'Segment1 has value 1');
   assert.equal(contextResult['segment2'], 1, 'Segment2 has value 1');
 });
+
+QUnit.asyncTest( "personalize decision event", function( assert ) {
+  expect(10);
+  var personalizeDecisionPushCount = 0;
+  _tcaq = {
+    'push':function(stf) {
+      console.log(stf);
+      if ( personalizeDecisionPushCount == 0 ) {
+        assert.equal( stf[0], 'captureView',  'capture view received');
+        assert.equal( stf[1], 'Content View',  'capture view is of type content view');
+        assert.equal( stf[2].person_udf1, "some-value", 'value correctly assigned from context' );
+        assert.equal( stf[2].person_udf2, "some-other-value", 'value correctly assigned from promise based context' );
+        assert.equal( stf[2].person_udf3, "some-other-value", 'same  value correctly assigned to a second UDF' );
+        QUnit.start();
+      }
+      else {
+        assert.equal( stf[0], 'capture',  'capture view received');
+        assert.equal( stf[1], 'Campaign Action',  'capture view is of type campaign action');
+        assert.equal( stf[2].campaignid, "my-agent", 'value correctly assigned from event' );
+        assert.equal( stf[2].campaignname, "Test Agent", 'value correctly assigned from event' );
+        assert.equal( stf[2].actionName, "test_decision", 'value correctly assigned from event' );
+      }
+      personalizeDecisionPushCount++;
+    }
+  };
+  var settings = {
+    acquia_lift_profiles: {
+      udfMappings: {
+        person: {
+          person_udf1: "my_first_plugin__some-context",
+          person_udf2: "my_promise_plugin__some-other-context",
+          // Test that another UDF can be mapped to the same context.
+          person_udf3: "my_promise_plugin__some-other-context"
+        }
+      },
+      udfMappingContextSeparator: '__'
+    },
+    personalize : {
+      agent_map : {
+        'my-agent': {
+          'active': 1,
+          'cache_decisions': false,
+          'enabled_contexts': [],
+          'type': 'test_agent',
+          'title' : 'Test Agent'
+        }
+      }
+    }
+  };
+
+  // We need to mock the getVisitorContexts() method as this is called by the
+  // init method, which we're testing here. We just need to make it call the
+  // callback that will be passed into it with the values for the contexts
+  // specified.
+  Drupal.personalize.getVisitorContexts = function(plugins, callback) {
+    var values = {
+      'my_first_plugin': {
+        'some-context': 'some-value'
+      },
+      'my_promise_plugin': {
+        'some-other-context': 'some-other-value'
+      }
+    };
+    callback.call(null, values);
+  };
+  Drupal.acquia_lift_profiles.init(settings);
+  $(document).trigger("personalizeDecision", [{}, "test_decision", "test_osid", "my-agent" ]);
+});
+


### PR DESCRIPTION
Pushes the appropriate captures to _tcaq for those events. Also, read settings from personalize to get the agent label.
