### PR TITLE
CH-1120: Use Drupal's element-hidden class to hide the variation edit icon

### DIFF
--- a/css/acquia_lift.buttons.css
+++ b/css/acquia_lift.buttons.css
@@ -2,7 +2,6 @@
 input[type="submit"].acquia-lift-submit-button,
 .acquia-lift-cancel-button {
   -webkit-appearance: none;
-  -moz-box-sizing: border-box;
   box-sizing: border-box;
   margin: 0.2963em;
   max-width: 100%;

--- a/css/acquia_lift.messagebox.css
+++ b/css/acquia_lift.messagebox.css
@@ -1,5 +1,4 @@
 #acquia-lift-message-box {
-  -moz-box-sizing: border-box;
   box-sizing: border-box;
   position: fixed;
   min-width: 50%;

--- a/css/acquia_lift.personalize.theme.css
+++ b/css/acquia_lift.personalize.theme.css
@@ -13,6 +13,9 @@
   cursor: pointer;
   vertical-align: middle;
 }
+#navbar-administration a.acquia-lift-page-variation-toggle-hidden {
+  display: none;
+}
 #navbar-administration .acquia-lift-page-variation-toggle.acquia-lift-page-variation-toggle-disabled {
   background-image: url("../images/page-variation-toggle-disabled.png");
 }

--- a/css/acquia_lift.reports.css
+++ b/css/acquia_lift.reports.css
@@ -30,8 +30,7 @@
 }
 
 .acquia-lift-report-section-options {
-  -moz-box-sizing: border-box;
-       box-sizing: border-box;
+  box-sizing: border-box;
   clear: both;
   width: 100%;
   min-width: 100%;
@@ -81,8 +80,7 @@ html[dir="rtl"] .lift-winner:after {
   font-family: sans-serif;
 }
 .lift-graph * {
-  -moz-box-sizing: border-box;
-       box-sizing: border-box;
+  box-sizing: border-box;
 }
 .lift-graph-container {
   padding-right: 1em;

--- a/css/navbar/navbar-overlay-child.css
+++ b/css/navbar/navbar-overlay-child.css
@@ -15,7 +15,6 @@
 }
 
 #overlay {
-  -moz-box-sizing: border-box;
   box-sizing: border-box;
   display: block;
   margin: 0 auto;

--- a/css/navbar/navbar.module.css
+++ b/css/navbar/navbar.module.css
@@ -23,7 +23,6 @@
   background-repeat: no-repeat;
   border: none;
   box-shadow: none;
-  -moz-box-sizing: border-box;
   box-sizing: border-box;
   bottom: auto;
   color: black;

--- a/css/navbar/navbar.theme.css
+++ b/css/navbar/navbar.theme.css
@@ -158,6 +158,5 @@
  */
 #navbar-administration *:before,
 #navbar-administration *:after {
-  -moz-box-sizing: content-box;
   box-sizing: content-box;
 }

--- a/js/acquia_lift.personalize.js
+++ b/js/acquia_lift.personalize.js
@@ -1798,7 +1798,7 @@
         this.$el
           .toggleClass('acquia-lift-page-variation-toggle-disabled', currentCampaign.get('activeVariation') == 0) // There is no toggle available for the control variation.
           .toggleClass('acquia-lift-page-variation-toggle-active', this.model.get('isActive'))
-          .toggleClass('element-hidden', currentCampaign instanceof Drupal.acquiaLiftUI.MenuCampaignABModel);
+          .toggleClass('acquia-lift-page-variation-toggle-hidden', currentCampaign instanceof Drupal.acquiaLiftUI.MenuCampaignABModel === false);
       },
 
       /**

--- a/js/acquia_lift.personalize.js
+++ b/js/acquia_lift.personalize.js
@@ -1798,7 +1798,7 @@
         this.$el
           .toggleClass('acquia-lift-page-variation-toggle-disabled', currentCampaign.get('activeVariation') == 0) // There is no toggle available for the control variation.
           .toggleClass('acquia-lift-page-variation-toggle-active', this.model.get('isActive'))
-          .toggle(currentCampaign instanceof Drupal.acquiaLiftUI.MenuCampaignABModel);
+          .toggleClass('element-hidden', currentCampaign instanceof Drupal.acquiaLiftUI.MenuCampaignABModel);
       },
 
       /**


### PR DESCRIPTION
Currently, the icon is hidden with jquery's toggle(). This is problematic in that it adds inline style `display: inline;` and overrides the css.
