### PR TITLE
Adding an alter hook for page context

### DIFF
--- a/acquia_lift_profiles/acquia_lift_profiles.module
+++ b/acquia_lift_profiles/acquia_lift_profiles.module
@@ -453,6 +453,10 @@ function acquia_lift_profiles_node_page_context($node = NULL, $primary = FALSE) 
     // Add the thumbnail image if specified in the content type and supplied.
     $page_context['thumbnail_url'] = acquia_lift_profiles_thumbnail_image('node', $node, $node->type);
   }
+
+  // Allow other modules to alter the page context.
+  drupal_alter('acquia_lift_profiles_page_context', $page_context);
+
   return $page_context;
 }
 


### PR DESCRIPTION
Because alter all the things.

This allows developers to change the page context before it's rendered. Use case for me was to load in the image URL of a referenced commerce product for Content Recommendations.
