### PR TITLE
Ch 1306 - allow capture of a visitor's identity from a configurable querystring param

### DIFF
--- a/acquia_lift_profiles/acquia_lift_profiles.admin.inc
+++ b/acquia_lift_profiles/acquia_lift_profiles.admin.inc
@@ -45,9 +45,26 @@ function acquia_lift_profiles_admin_form($form, &$form_state) {
 
   $form['acquia_lift_profiles_capture_identity'] = array(
     '#type' => 'checkbox',
-    '#title' => t('Capture Identity'),
+    '#title' => t('Capture identity on login / register'),
     '#description' => t('Check this if you want Acquia Lift Profiles to capture the identity of the user upon login or registration. This means sending their email address to the Acquia Lift Profile Manager.'),
     '#default_value' => variable_get('acquia_lift_profiles_capture_identity', FALSE),
+  );
+  $form['acquia_lift_profiles_identity_param'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Acquia Lift Profiles identity parameter'),
+    '#description' => t('Specify a querystring parameter that can be used to identify the visitor. If specified, and the querystring parameter is present, the visitor\'s identity will be sent the Acquia Lift Profile Manager.'),
+    '#default_value' => variable_get('acquia_lift_profiles_identity_param', ''),
+  );
+  $form['acquia_lift_profiles_identity_type_param'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Acquia Lift Profiles identity type parameter'),
+    '#description' => t('If the type of identity can be something other than an email address, specify a querystring parameter that can be used to tell Acquia Lift Profile Manager what the type of identity is.'),
+    '#default_value' => variable_get('acquia_lift_profiles_identity_type_param', ''),
+    '#states' => array(
+      'visible' => array(
+        ':input[name="acquia_lift_profiles_identity_param"]' =>  array('!value' => '')
+      )
+    )
   );
   $vocabularies = taxonomy_get_vocabularies();
   $mappings = variable_get('acquia_lift_profiles_vocabulary_mappings', array());
@@ -185,7 +202,18 @@ function acquia_lift_profiles_admin_form_submit($form, &$form_state) {
     visitor_actions_clear_subscribers('user_login');
     visitor_actions_clear_subscribers('user_register');
   }
-  foreach (array('acquia_lift_profiles_account_name', 'acquia_lift_profiles_api_url', 'acquia_lift_profiles_access_key', 'acquia_lift_profiles_secret_key', 'acquia_lift_profiles_js_path', 'acquia_lift_profiles_capture_identity', 'acquia_lift_profiles_vocabulary_mappings') as $key) {
+  $variables = array(
+    'acquia_lift_profiles_account_name',
+    'acquia_lift_profiles_api_url',
+    'acquia_lift_profiles_access_key',
+    'acquia_lift_profiles_secret_key',
+    'acquia_lift_profiles_js_path',
+    'acquia_lift_profiles_capture_identity',
+    'acquia_lift_profiles_identity_param',
+    'acquia_lift_profiles_identity_type_param',
+    'acquia_lift_profiles_vocabulary_mappings'
+  );
+  foreach ($variables as $key) {
     variable_set($key, $form_state['values'][$key]);
   }
 
@@ -222,6 +250,7 @@ function acquia_lift_profiles_admin_form_submit($form, &$form_state) {
     variable_set('acquia_lift_profiles_udf_mappings', $mapped_contexts);
   }
 
+  drupal_set_message(t('The configuration settings have been saved.'), 'status');
 }
 
 /**

--- a/acquia_lift_profiles/acquia_lift_profiles.admin.inc
+++ b/acquia_lift_profiles/acquia_lift_profiles.admin.inc
@@ -51,14 +51,14 @@ function acquia_lift_profiles_admin_form($form, &$form_state) {
   );
   $form['acquia_lift_profiles_identity_param'] = array(
     '#type' => 'textfield',
-    '#title' => t('Acquia Lift Profiles identity parameter'),
-    '#description' => t('Specify a querystring parameter that can be used to identify the visitor. If specified, and the querystring parameter is present, the visitor\'s identity will be sent the Acquia Lift Profile Manager.'),
+    '#title' => t('Identity parameter'),
+    '#description' => t('The query string parameter for a specific item of visitor information, such as the visitor\'s email address or social media username (for example, ?al=person@example.com), which is sent to Acquia Lift Web.'),
     '#default_value' => variable_get('acquia_lift_profiles_identity_param', ''),
   );
   $form['acquia_lift_profiles_identity_type_param'] = array(
     '#type' => 'textfield',
-    '#title' => t('Acquia Lift Profiles identity type parameter'),
-    '#description' => t('If the type of identity can be something other than an email address, specify a querystring parameter that can be used to tell Acquia Lift Profile Manager what the type of identity is.'),
+    '#title' => t('Identity type parameter'),
+    '#description' => t('The query string parameter for the category of the visitor\'s identity information (for example, ?al=person@example.com&alt=email). Acquia Lift Web accepts only the following values: email, account, facebook, twitter, name.'),
     '#default_value' => variable_get('acquia_lift_profiles_identity_type_param', ''),
     '#states' => array(
       'visible' => array(

--- a/acquia_lift_profiles/acquia_lift_profiles.install
+++ b/acquia_lift_profiles/acquia_lift_profiles.install
@@ -75,6 +75,8 @@ function acquia_lift_profiles_uninstall() {
   variable_del('acquia_lift_profiles_vocabulary_mappings');
   variable_del('acquia_lift_profiles_tracked_actions');
   variable_del('acquia_lift_profiles_udf_mappings');
+  variable_del('acquia_lift_profiles_identity_param');
+  variable_del('acquia_lift_profiles_identity_type_param');
 
   // Delete the menu link
   $item = _acquia_lift_profiles_get_menu_link();

--- a/acquia_lift_profiles/acquia_lift_profiles.module
+++ b/acquia_lift_profiles/acquia_lift_profiles.module
@@ -147,6 +147,8 @@ function acquia_lift_profiles_page_build(&$page) {
     // it.
     'udfMappingContextSeparator' => PERSONALIZE_TARGETING_ADMIN_SEPARATOR,
   );
+  // If there are querystring parameters present corresponding to the configured
+  // identity params, we add the identity and identity type to the js settings.
   $identity_param = variable_get('acquia_lift_profiles_identity_param', '');
   $identity_type_param = variable_get('acquia_lift_profiles_identity_type_param', '');
   if (!empty($identity_param)) {
@@ -154,9 +156,9 @@ function acquia_lift_profiles_page_build(&$page) {
     if (isset($all_params[$identity_param])) {
       $settings['identity'] = check_plain($all_params[$identity_param]);
       $settings['identityType'] = 'email';
-    }
-    if (!empty($identity_type_param) && isset($all_params[$identity_type_param])) {
-      $settings['identityType'] = check_plain($all_params[$identity_type_param]);
+      if (!empty($identity_type_param) && isset($all_params[$identity_type_param])) {
+        $settings['identityType'] = check_plain($all_params[$identity_type_param]);
+      }
     }
   }
 

--- a/acquia_lift_profiles/acquia_lift_profiles.module
+++ b/acquia_lift_profiles/acquia_lift_profiles.module
@@ -147,6 +147,18 @@ function acquia_lift_profiles_page_build(&$page) {
     // it.
     'udfMappingContextSeparator' => PERSONALIZE_TARGETING_ADMIN_SEPARATOR,
   );
+  $identity_param = variable_get('acquia_lift_profiles_identity_param', '');
+  $identity_type_param = variable_get('acquia_lift_profiles_identity_type_param', '');
+  if (!empty($identity_param)) {
+    $all_params = drupal_get_query_parameters();
+    if (isset($all_params[$identity_param])) {
+      $settings['identity'] = check_plain($all_params[$identity_param]);
+      $settings['identityType'] = 'email';
+    }
+    if (!empty($identity_type_param) && isset($all_params[$identity_type_param])) {
+      $settings['identityType'] = check_plain($all_params[$identity_type_param]);
+    }
+  }
 
   $page_context = acquia_lift_profiles_get_page_context();
   foreach ($page_context as $name => $value) {

--- a/acquia_lift_profiles/js/acquia_lift_profiles.js
+++ b/acquia_lift_profiles/js/acquia_lift_profiles.js
@@ -132,7 +132,7 @@ var _tcwq = _tcwq || [];
     if (identityCaptured || !(DrupalSettings.captureIdentity && context['mail'])) {
       return;
     }
-    pushCaptureIdentity(context['mail'], 'email');
+    _tcaq.push( [ 'captureIdentity', context['mail'], 'email', {'evalSegments': true}] );
     identityCaptured = true;
   };
 
@@ -248,7 +248,7 @@ var _tcwq = _tcwq || [];
           }, settings.acquia_lift_profiles.pageContext, udfValues);
           _tcaq.push( [ 'captureView', 'Content View', pageInfo ] );
 
-          sendURLIdentity();
+          Drupal.acquia_lift_profiles.sendURLIdentity();
 
           initialized = true;
         };

--- a/acquia_lift_profiles/js/acquia_lift_profiles.js
+++ b/acquia_lift_profiles/js/acquia_lift_profiles.js
@@ -19,7 +19,7 @@ var _tcwq = _tcwq || [];
     'attach': function (context, settings) {
       Drupal.acquia_lift_profiles.init(settings);
       Drupal.acquia_lift_profiles.addActionListener(settings);
-      processServerSideActions(settings);
+      Drupal.acquia_lift_profiles.processServerSideActions(settings);
       Drupal.acquia_lift_profiles.registerSegmentsCallback();
     }
   };
@@ -335,6 +335,29 @@ var _tcwq = _tcwq || [];
         }
       },
 
+      /**
+       * Goes through the server-side actions and calls the appropriate function for
+       * each one, passing in the event context.
+       *
+       * @param settings
+       */
+      'processServerSideActions': function (settings) {
+        if (settings.acquia_lift_profiles.serverSideActions) {
+          for (var actionName in settings.acquia_lift_profiles.serverSideActions) {
+            if (settings.acquia_lift_profiles.serverSideActions.hasOwnProperty(actionName)) {
+              for (var i in settings.acquia_lift_profiles.serverSideActions[actionName]) {
+                if (settings.acquia_lift_profiles.serverSideActions[actionName].hasOwnProperty(i) && !settings.acquia_lift_profiles.serverSideActions[actionName][i].processed) {
+                  // Process the event.
+                  this.processEvent(actionName, settings, settings.acquia_lift_profiles.serverSideActions[actionName][i]);
+                  // Mark this event has having been processed so that it doesn't get sent again.
+                  settings.acquia_lift_profiles.serverSideActions[actionName][i].processed = 1;
+                }
+              }
+            }
+          }
+        }
+      },
+
       // Holds the functions that should be called for particular events.
       'specialEvents': {
         'user_login': pushCaptureEmail,
@@ -349,33 +372,11 @@ var _tcwq = _tcwq || [];
         initialized = false;
         initializing = false;
         agentNameToLabel = {};
+        identityCaptured = false;
         $(document).unbind('personalizeDecision', this["processPersonalizeDecision"]);
         $(document).unbind('sentGoalToAgent', this["processSentGoalToAgent"]);
       }
     }
   })();
-
-  /**
-   * Goes through the server-side actions and calls the appropriate function for
-   * each one, passing in the event context.
-   *
-   * @param settings
-   */
-  function processServerSideActions(settings) {
-    if (settings.acquia_lift_profiles.serverSideActions) {
-      for (var actionName in settings.acquia_lift_profiles.serverSideActions) {
-        if (settings.acquia_lift_profiles.serverSideActions.hasOwnProperty(actionName)) {
-          for (var i in settings.acquia_lift_profiles.serverSideActions[actionName]) {
-            if (settings.acquia_lift_profiles.serverSideActions[actionName].hasOwnProperty(i) && !settings.acquia_lift_profiles.serverSideActions[actionName][i].processed) {
-              // Process the event.
-              Drupal.acquia_lift_profiles.processEvent(actionName, settings, settings.acquia_lift_profiles.serverSideActions[actionName][i]);
-              // Mark this event has having been processed so that it doesn't get sent again.
-              settings.acquia_lift_profiles.serverSideActions[actionName][i].processed = 1;
-            }
-          }
-        }
-      }
-    }
-  }
 
 })(jQuery);

--- a/acquia_lift_profiles/qunit/tests.js
+++ b/acquia_lift_profiles/qunit/tests.js
@@ -164,41 +164,23 @@ QUnit.test("get context values with cache", function( assert ) {
 });
 
 QUnit.asyncTest( "personalize decision event", function( assert ) {
-  expect(10);
+  expect(5);
   Drupal.acquia_lift_profiles.resetAll();
-  var personalizeDecisionPushCount = 0;
   _tcaq = {
-    'push':function(stf) {
-      console.log(stf);
-      if ( personalizeDecisionPushCount == 0 ) {
-        assert.equal( stf[0], 'captureView',  'capture view received');
-        assert.equal( stf[1], 'Content View',  'capture view is of type content view');
-        assert.equal( stf[2].person_udf1, "some-value", 'value correctly assigned from context' );
-        assert.equal( stf[2].person_udf2, "some-other-value", 'value correctly assigned from promise based context' );
-        assert.equal( stf[2].person_udf3, "some-other-value", 'same  value correctly assigned to a second UDF' );
-
-      }
-      else {
-        assert.equal( stf[0], 'capture',  'capture view received');
-        assert.equal( stf[1], 'Campaign Action',  'capture view is of type campaign action');
-        assert.equal( stf[2].campaignid, "my-agent", 'value correctly assigned from event' );
-        assert.equal( stf[2].campaignname, "Test Agent", 'value correctly assigned from event' );
-        assert.equal( stf[2].actionName, "test_decision", 'value correctly assigned from event' );
+    'push':function(args) {
+      if ( args[1] == 'Campaign Action' ) {
+        assert.equal( args[0], 'capture',  'capture view received');
+        assert.equal( args[1], 'Campaign Action',  'capture view is of type campaign action');
+        assert.equal( args[2].campaignid, "my-agent", 'value correctly assigned from event' );
+        assert.equal( args[2].campaignname, "Test Agent", 'value correctly assigned from event' );
+        assert.equal( args[2].actionName, "test_decision", 'value correctly assigned from event' );
         QUnit.start();
       }
-      personalizeDecisionPushCount++;
     }
   };
   var settings = {
     acquia_lift_profiles: {
-      udfMappings: {
-        person: {
-          person_udf1: "my_first_plugin__some-context",
-          person_udf2: "my_promise_plugin__some-other-context",
-          // Test that another UDF can be mapped to the same context.
-          person_udf3: "my_promise_plugin__some-other-context"
-        }
-      },
+      udfMappings: {},
       udfMappingContextSeparator: '__'
     },
     personalize : {
@@ -215,59 +197,31 @@ QUnit.asyncTest( "personalize decision event", function( assert ) {
   };
 
   // We need to mock the getVisitorContexts() method as this is called by the
-  // init method, which we're testing here. We just need to make it call the
-  // callback that will be passed into it with the values for the contexts
-  // specified.
+  // init method.
   Drupal.personalize.getVisitorContexts = function(plugins, callback) {
-    var values = {
-      'my_first_plugin': {
-        'some-context': 'some-value'
-      },
-      'my_promise_plugin': {
-        'some-other-context': 'some-other-value'
-      }
-    };
-    callback.call(null, values);
+    callback.call(null, {});
   };
   Drupal.acquia_lift_profiles.init(settings);
   $(document).trigger("personalizeDecision", [{}, "test_decision", "test_osid", "my-agent" ]);
 });
 
 QUnit.asyncTest( "sent goal to agent event", function( assert ) {
-  expect(9);
+  expect(4);
   Drupal.acquia_lift_profiles.resetAll();
-  var personalizeDecisionPushCount = 0;
   _tcaq = {
-    'push':function(stf) {
-      console.log(stf);
-      if ( personalizeDecisionPushCount == 0 ) {
-        assert.equal( stf[0], 'captureView',  'capture view received');
-        assert.equal( stf[1], 'Content View',  'capture view is of type content view');
-        assert.equal( stf[2].person_udf1, "some-value", 'value correctly assigned from context' );
-        assert.equal( stf[2].person_udf2, "some-other-value", 'value correctly assigned from promise based context' );
-        assert.equal( stf[2].person_udf3, "some-other-value", 'same  value correctly assigned to a second UDF' );
-
-      }
-      else {
-        assert.equal( stf[0], 'capture',  'capture received');
-        assert.equal( stf[1], 'goal-event',  'capture view is of type goal-event');
-        assert.equal( stf[2].campaignid, "my-agent", 'value correctly assigned from event' );
-        assert.equal( stf[2].campaignname, "Test Agent", 'value correctly assigned from event' );
+    'push':function(args) {
+      if ( args[1] == 'goal-event' ) {
+        assert.equal( args[0], 'capture',  'capture received');
+        assert.equal( args[1], 'goal-event',  'capture view is of type goal-event');
+        assert.equal( args[2].campaignid, "my-agent", 'value correctly assigned from event' );
+        assert.equal( args[2].campaignname, "Test Agent", 'value correctly assigned from event' );
         QUnit.start();
       }
-      personalizeDecisionPushCount++;
     }
   };
   var settings = {
     acquia_lift_profiles: {
-      udfMappings: {
-        person: {
-          person_udf1: "my_first_plugin__some-context",
-          person_udf2: "my_promise_plugin__some-other-context",
-          // Test that another UDF can be mapped to the same context.
-          person_udf3: "my_promise_plugin__some-other-context"
-        }
-      },
+      udfMappings: {},
       udfMappingContextSeparator: '__'
     },
     personalize : {
@@ -284,19 +238,9 @@ QUnit.asyncTest( "sent goal to agent event", function( assert ) {
   };
 
   // We need to mock the getVisitorContexts() method as this is called by the
-  // init method, which we're testing here. We just need to make it call the
-  // callback that will be passed into it with the values for the contexts
-  // specified.
+  // init method.
   Drupal.personalize.getVisitorContexts = function(plugins, callback) {
-    var values = {
-      'my_first_plugin': {
-        'some-context': 'some-value'
-      },
-      'my_promise_plugin': {
-        'some-other-context': 'some-other-value'
-      }
-    };
-    callback.call(null, values);
+    callback.call(null, {});
   };
   Drupal.acquia_lift_profiles.init(settings);
   $(document).trigger("sentGoalToAgent", ["my-agent", "goal-event", "goal-value"]);

--- a/acquia_lift_profiles/tests/acquia_lift_profiles.test
+++ b/acquia_lift_profiles/tests/acquia_lift_profiles.test
@@ -202,6 +202,50 @@ class ALProfilesWebTest extends DrupalWebTestCase {
     $this->assertEqual($settings['acquia_lift_profiles']['available_segments'], $test_segments);
   }
 
+  /**
+   * Tests identity param configuration and js settings.
+   */
+  function testIdentityParams() {
+    $this->configureALProfiles();
+    $this->drupalLogin($this->admin_user);
+    // Test specifying a querystring param to use for capturing identity.
+    $this->drupalPost('admin/config/content/personalize/acquia_lift_profiles', array('acquia_lift_profiles_identity_param' => 'ali'), t('Save'));
+    $this->drupalLogout();
+
+    // Now visit the site as anon without passing any querystring params.
+    $this->drupalGet('');
+    $settings = $this->drupalGetSettings();
+    $alp_settings = $settings['acquia_lift_profiles'];
+    $this->assertFalse(isset($alp_settings['identity']));
+
+    // Now pass the configured identity param
+    $my_id = 'ohai';
+    $this->drupalGet('', array('query' => array('ali' => $my_id)));
+    $settings = $this->drupalGetSettings();
+    $alp_settings = $settings['acquia_lift_profiles'];
+    $this->assertEqual($alp_settings['identity'], $my_id);
+    $this->assertEqual($alp_settings['identityType'], 'email');
+
+    // Set the identity type param
+    $this->drupalLogin($this->admin_user);
+    $this->drupalPost('admin/config/content/personalize/acquia_lift_profiles', array('acquia_lift_profiles_identity_type_param' => 'alit'), t('Save'));
+    $this->drupalLogout();
+    // Pass the configured identity param and the identity_type param
+    $my_id = 'ohai';
+    $this->drupalGet('', array('query' => array('ali' => $my_id, 'alit' => 'socialtastic')));
+    $settings = $this->drupalGetSettings();
+    $alp_settings = $settings['acquia_lift_profiles'];
+    $this->assertEqual($alp_settings['identity'], $my_id);
+    $this->assertEqual($alp_settings['identityType'], 'socialtastic');
+
+    // Pass the configured identity type param without the identity param
+    $this->drupalGet('', array('query' => array('alit' => 'socialtastic')));
+    $settings = $this->drupalGetSettings();
+    $alp_settings = $settings['acquia_lift_profiles'];
+    $this->assertFalse(isset($alp_settings['identity']));
+    $this->assertFalse(isset($alp_settings['identityType']));
+  }
+
   // Tests that configuring events to track in Acquia Lift Profiles makes the required calls to
   // the Acquia Lift Profiles API.
   function testSyncEvents() {


### PR DESCRIPTION
This PR sneaks in some unrelated changes to some of the qunit tests and also adds a test for processing server-side actions, as well as the qunit test for identity capture.
