### PR TITLE
Ch 1408 - Pause agents in Lift when they are paused in Drupal

### DIFF
--- a/acquia_lift.module
+++ b/acquia_lift.module
@@ -848,10 +848,18 @@ function acquia_lift_process_queue($exit_on_finish = TRUE) {
       $function($item->data);
       $queue->deleteItem($item);
     }
+    catch(AcquiaLiftClientErrorException $e) {
+      // If our worker callback throws an exception indicating a client error in
+      // a request made to Lift, we should abort the processing of the queue and
+      // set a message to let the user know things went wrong.
+      drupal_set_message(t('An error occurred while syncing your campaign information to Lift: @error', array('@error' => $e->getMessage())));
+      $queue->deleteQueue();
+      break;
+    }
     catch (AcquiaLiftException $e) {
+      // For other types of errors, allow the item to be retried.
       $queue->releaseItem($item);
     }
-
   }
   _personalize_agent_verification_cache_clear();
 

--- a/acquia_lift.module
+++ b/acquia_lift.module
@@ -478,6 +478,21 @@ function acquia_lift_personalize_agent_presave($agent) {
 }
 
 /**
+ * Implements hook_personalize_agent_update_status().
+ */
+function acquia_lift_personalize_agent_update_status($agent_name, $old_status, $status) {
+  $agent_data = personalize_agent_load($agent_name);
+  if (!acquia_lift_owns_agent($agent_data)) {
+    return;
+  }
+  $agent_instance = personalize_agent_load_agent($agent_name, TRUE);
+  if (!$agent_instance instanceof AcquiaLiftAgentInterface) {
+    return;
+  }
+  $agent_instance->syncAgentStatus();
+}
+
+/**
  * Implements hook_personalize_visitor_contexts().
  */
 function acquia_lift_personalize_visitor_context() {

--- a/includes/acquia_lift.classes.inc
+++ b/includes/acquia_lift.classes.inc
@@ -208,6 +208,18 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
     return $code >= 500 && $code < 600;
   }
 
+  /**
+   * Maps the passed in response code to an exception class to use.
+   *
+   * If the response code passed in constitutes a successful response,
+   * NULL is returned. If it does not constitute a 400 or 500 error,
+   * NULL is returned.
+   *
+   * @param $code
+   *   The response code to map.
+   * @return null|string
+   *   The exception class to use or NULL.
+   */
   protected static function mapBadResponseToExceptionClass($code) {
     if (self::isSuccessful($code)) {
       return NULL;
@@ -474,6 +486,18 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
     }
   }
 
+  /**
+   * Figures out the correct exception to throw and throws it.
+   *
+   * @param $response_code
+   *   The response code, e.g. 404.
+   * @param $fail_msg
+   *   The message to use for the exception, and for logging if $log_failure it TRUE.
+   * @param array $vars
+   *   Variables to pass to the message.
+   * @param bool $log_failure
+   *   Whether failures should be logged or not
+   */
   public function handleBadResponse($response_code, $fail_msg, $vars = array(), $log_failure = TRUE) {
     if ($exception_class = self::mapBadResponseToExceptionClass($response_code)) {
       if ($log_failure) {

--- a/includes/acquia_lift.classes.inc
+++ b/includes/acquia_lift.classes.inc
@@ -160,6 +160,62 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
   }
 
   /**
+   * Whether the passed in status code represents a successful response.
+   *
+   * @param $code
+   *   The status code.
+   * @return bool
+   *   TRUE if the code represents a client error, FALSE otherwise.
+   */
+  public static function isSuccessful($code) {
+    return $code >= 200 && $code < 300;
+  }
+
+  /**
+   * Whether the passed in status code represents a client side error.
+   *
+   * @param $code
+   *   The status code.
+   * @return bool
+   *   TRUE if the code represents a client error, FALSE otherwise.
+   */
+  public static function isClientError($code) {
+    return $code >= 400 && $code < 500;
+  }
+
+  /**
+   * Whether the passed in status code represents a server side error.
+   *
+   * @param $code
+   *   The status code.
+   * @return bool
+   *   TRUE if the code represents a server error, FALSE otherwise.
+   */
+  public static function isServerError($code) {
+    return $code >= 500 && $code < 600;
+  }
+
+  protected static function mapBadResponseToExceptionClass($code) {
+    if (self::isSuccessful($code)) {
+      return NULL;
+    }
+    if (self::isClientError($code)) {
+      switch ($code) {
+        case 404:
+          return 'AcquiaLiftNotFoundException';
+        case 403:
+          return 'AcquiaLiftForbiddenException';
+        default:
+          return 'AcquiaLiftClientErrorException';
+      }
+    }
+    elseif (self::isServerError($code)) {
+      return 'AcquiaLiftServerErrorException';
+    }
+    return NULL;
+  }
+
+  /**
    * Determines whether the passed in string is valid as an owner code.
    *
    * @param $str
@@ -354,6 +410,7 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
    *   TRUE if the agent has been saved to Acquia Lift, FALSE otherwise.
    */
   public function saveAgent($machine_name, $label, $decision_style, $status = 'enabled', $control_rate = 0.1, $explore_rate = .2, $sticky = TRUE) {
+    $status = self::mapStatus($status);
     $url = $this->generateEndpoint("/agent-api/$machine_name");
     $agent = array(
       'name' => $label,
@@ -372,8 +429,7 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
       $this->logger()->log(PersonalizeLogLevel::INFO, $success_msg, $vars);
     }
     else {
-      $this->logger()->log(PersonalizeLogLevel::ERROR, $fail_msg, $vars);
-      throw new AcquiaLiftException($fail_msg);
+      $this->handleBadResponse($response->code, $fail_msg, $vars);
     }
   }
 
@@ -384,8 +440,6 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
    *   The machine of the agent.
    * @param $status
    *   The status to set the agent to.
-   * @return boolean
-   *   TRUE if the agent has been saved to Acquia Lift, FALSE otherwise.
    * @throws AcquiaLiftException
    */
   public function updateAgentStatus($machine_name, $status) {
@@ -427,9 +481,27 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
       $this->logger()->log(PersonalizeLogLevel::INFO, $success_msg, $vars);
     }
     else {
-      $this->logger()->log(PersonalizeLogLevel::ERROR, $fail_msg, $vars);
-      throw new AcquiaLiftException($fail_msg);
+      $this->handleBadResponse($response->code, $fail_msg, $vars);
     }
+  }
+
+  public function handleBadResponse($response_code, $fail_msg, $vars = array(), $log_failure = TRUE) {
+    if ($exception_class = self::mapBadResponseToExceptionClass($response_code)) {
+      if ($log_failure) {
+        $this->logger()->log(PersonalizeLogLevel::ERROR, $fail_msg, $vars);
+      }
+      throw new $exception_class($fail_msg);
+    }
+    if (self::isSuccessful($response_code)) {
+      // If the response wasn't actually bad but we still got here somehow, just
+      // log a warning and return.
+      if ($log_failure) {
+        $this->logger()->log(PersonalizeLogLevel::WARNING, $fail_msg, $vars);
+      }
+      return;
+    }
+    // Otherwise throw a generic exception.
+    throw new AcquiaLiftException($fail_msg);
   }
 
   /**
@@ -453,8 +525,7 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
       $this->logger()->log(PersonalizeLogLevel::INFO, $success_msg, $vars);
     }
     else {
-      $this->logger()->log(PersonalizeLogLevel::ERROR, $fail_msg, $vars);
-      throw new AcquiaLiftException($fail_msg);
+      $this->handleBadResponse($response->code, $fail_msg, $vars);
     }
   }
 
@@ -482,8 +553,7 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
       $this->logger()->log(PersonalizeLogLevel::INFO, $success_msg, $vars);
     }
     else {
-      $this->logger()->log(PersonalizeLogLevel::ERROR, $fail_msg, $vars);
-      throw new AcquiaLiftException($fail_msg);
+      $this->handleBadResponse($response->code, $fail_msg, $vars);
     }
   }
 
@@ -502,8 +572,7 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
       $this->logger()->log(PersonalizeLogLevel::INFO, $success_msg, $vars);
     }
     else {
-      $this->logger()->log(PersonalizeLogLevel::ERROR, $fail_msg, $vars);
-      throw new AcquiaLiftException($fail_msg);
+      $this->handleBadResponse($response->code, $fail_msg, $vars);
     }
   }
 
@@ -523,8 +592,7 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
       $this->logger()->log(PersonalizeLogLevel::INFO, $success_msg, $vars);
     }
     else {
-      $this->logger()->log(PersonalizeLogLevel::ERROR, $fail_msg, $vars);
-      throw new AcquiaLiftException($fail_msg);
+      $this->handleBadResponse($response->code, $fail_msg, $vars);
     }
   }
 
@@ -547,8 +615,7 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
       $this->logger()->log(PersonalizeLogLevel::INFO, $success_msg, $vars);
     }
     else {
-      $this->logger()->log(PersonalizeLogLevel::ERROR, $fail_msg, $vars);
-      throw new AcquiaLiftException($fail_msg);
+      $this->handleBadResponse($response->code, $fail_msg, $vars);
     }
   }
 
@@ -573,8 +640,7 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
       $this->logger()->log(PersonalizeLogLevel::INFO, $success_msg, $vars);
     }
     else {
-      $this->logger()->log(PersonalizeLogLevel::ERROR, $fail_msg, $vars);
-      throw new AcquiaLiftException($fail_msg);
+      $this->handleBadResponse($response->code, $fail_msg, $vars);
     }
   }
 
@@ -602,8 +668,7 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
       $this->logger()->log(PersonalizeLogLevel::INFO, $success_msg, $vars);
     }
     else {
-      $this->logger()->log(PersonalizeLogLevel::ERROR, $fail_msg, $vars);
-      throw new AcquiaLiftException($fail_msg);
+      $this->handleBadResponse($response->code, $fail_msg, $vars);
     }
   }
 
@@ -628,8 +693,7 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
       $this->logger()->log(PersonalizeLogLevel::INFO, $success_msg, $vars);
     }
     else {
-      $this->logger()->log(PersonalizeLogLevel::ERROR, $fail_msg, $vars);
-      throw new AcquiaLiftException($fail_msg);
+      $this->handleBadResponse($response->code, $fail_msg, $vars);
     }
   }
 
@@ -651,8 +715,7 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
       $this->logger()->log(PersonalizeLogLevel::INFO, $success_msg, $vars);
     }
     else {
-      $this->logger()->log(PersonalizeLogLevel::ERROR, $fail_msg, $vars);
-      throw new AcquiaLiftException($fail_msg);
+      $this->handleBadResponse($response->code, $fail_msg, $vars);
     }
   }
 
@@ -668,13 +731,13 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
   public function getAgent($machine_name) {
     $url = $this->generateEndpoint("/agent-api/$machine_name");
     $response = $this->httpClient()->get($url, array('Accept' => 'application/json'));
-    if ($response->code == 404) {
-      throw new AcquiaLiftNotFoundException('No such agent');
+    if ($response->code == 200) {
+      return json_decode($response->data, TRUE);
     }
-    if ($response->code != 200) {
-      throw new AcquiaLiftException('Could not retrieve agent from Acquia Lift');
+    else {
+      $this->handleBadResponse($response->code, 'Could not retrieve agent from Acquia Lift', array(), FALSE);
     }
-    return json_decode($response->data, TRUE);
+    return FALSE;
   }
 
   /**
@@ -688,13 +751,13 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
   public function getGoalsForAgent($agent_name) {
     $url = $this->generateEndpoint("/agent-api/$agent_name/goals");
     $response = $this->httpClient()->get($url, array('Accept' => 'application/json'));
-    if ($response->code == 404) {
-      throw new AcquiaLiftNotFoundException('No such agent');
+    if ($response->code == 200) {
+      return json_decode($response->data, TRUE);
     }
-    if ($response->code != 200) {
-      throw new AcquiaLiftException('Could not retrieve goals from Acquia Lift');
+    else {
+      $this->handleBadResponse($response->code, 'Could not retrieve goals from Acquia Lift', array(), FALSE);
     }
-    return json_decode($response->data, TRUE);
+    return FALSE;
   }
 
   /**
@@ -708,13 +771,14 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
   public function getPointsForAgent($agent_name) {
     $url = $this->generateEndpoint("/agent-api/$agent_name/points");
     $response = $this->httpClient()->get($url, array('Accept' => 'application/json'));
-    if ($response->code == 404) {
-      throw new AcquiaLiftNotFoundException('No such agent');
+
+    if ($response->code == 200) {
+      return json_decode($response->data, TRUE);
     }
-    if ($response->code != 200) {
-      throw new AcquiaLiftException('Could not retrieve decision points from Acquia Lift');
+    else {
+      $this->handleBadResponse($response->code, 'Could not retrieve decision points from Acquia Lift', array(), FALSE);
     }
-    return json_decode($response->data, TRUE);
+    return FALSE;
   }
 
   /**
@@ -731,13 +795,14 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
   public function getDecisionsForPoint($agent_name, $point_name) {
     $url = $this->generateEndpoint("/agent-api/$agent_name/points/{$point_name}/decisions");
     $response = $this->httpClient()->get($url, array('Accept' => 'application/json'));
-    if ($response->code == 404) {
-      throw new AcquiaLiftNotFoundException('No such decision point');
+
+    if ($response->code == 200) {
+      return json_decode($response->data, TRUE);
     }
-    if ($response->code != 200) {
-      throw new AcquiaLiftException('Could not retrieve decisions from Acquia Lift');
+    else {
+      $this->handleBadResponse($response->code, 'Could not retrieve decisions from Acquia Lift', array(), FALSE);
     }
-    return json_decode($response->data, TRUE);
+    return FALSE;
   }
 
   /**
@@ -756,13 +821,14 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
   public function getChoicesForDecision($agent_name, $point_name, $decision_name) {
     $url = $this->generateEndpoint("/agent-api/$agent_name/points/{$point_name}/decisions/$decision_name/choices");
     $response = $this->httpClient()->get($url, array('Accept' => 'application/json'));
-    if ($response->code == 404) {
-      throw new AcquiaLiftNotFoundException('No such decision');
+
+    if ($response->code == 200) {
+      return json_decode($response->data, TRUE);
     }
-    if ($response->code != 200) {
-      throw new AcquiaLiftException('Could not retrieve decisions from Acquia Lift');
+    else {
+      $this->handleBadResponse($response->code, 'Could not retrieve choices from Acquia Lift', array(), FALSE);
     }
-    return json_decode($response->data, TRUE);
+    return FALSE;
   }
 
   /**
@@ -788,10 +854,9 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
       return $existing_agents;
     }
     else {
-      $msg = 'Error retrieving agent list from Acquia Lift';
-      $this->logger()->log(PersonalizeLogLevel::ERROR, $msg);
-      throw new AcquiaLiftException($msg);
+      $this->handleBadResponse($response->code, 'Error retrieving agent list from Acquia Lift');
     }
+    return array();
   }
 
   /**
@@ -808,10 +873,9 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
       return $response['data']['options'];
     }
     else {
-      $msg = 'Error retrieving list of transforms options';
-      $this->logger()->log(PersonalizeLogLevel::ERROR, $msg);
-      throw new AcquiaLiftException($msg);
+      $this->handleBadResponse($response->code, 'Error retrieving list of transforms options');
     }
+    return FALSE;
   }
 
   /**
@@ -845,8 +909,7 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
       $this->logger()->log(PersonalizeLogLevel::INFO, $success_msg, $vars);
     }
     else {
-      $this->logger()->log(PersonalizeLogLevel::ERROR, $fail_msg, $vars);
-      throw new AcquiaLiftException($fail_msg);
+      $this->handleBadResponse($response->code, $fail_msg, $vars);
     }
   }
 
@@ -867,8 +930,7 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
       $this->logger()->log(PersonalizeLogLevel::INFO, $success_msg, $vars);
     }
     else {
-      $this->logger()->log(PersonalizeLogLevel::ERROR, $fail_msg, $vars);
-      throw new AcquiaLiftException($fail_msg);
+      $this->handleBadResponse($response->code, $fail_msg, $vars);
     }
   }
 
@@ -885,9 +947,8 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
     $url = $this->generateEndpoint("/transforms-list");
     $response = $this->httpClient()->get($url, array('Accept' => 'application/json'));
     if ($response->code != 200) {
-      $msg = 'Problem retrieving auto-targeting rules';
-      $this->logger()->log(PersonalizeLogLevel::ERROR, $msg);
-      throw new AcquiaLiftException($msg);
+      $this->handleBadResponse($response->code, 'Problem retrieving auto-targeting rules');
+      return FALSE;
     }
 
     $response = json_decode($response->data, TRUE);
@@ -926,9 +987,8 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
     $headers = array('Accept' => 'application/json');
     $response = $this->httpClient()->get($url, $headers);
     if ($response->code != 200) {
-      $msg = 'Problem retrieving potential targeting values';
-      $this->logger()->log(PersonalizeLogLevel::ERROR, $msg);
-      throw new AcquiaLiftException('Problem retrieving potential targeting values');
+      $this->handleBadResponse($response->code, 'Problem retrieving potential targeting values');
+      return array();
     }
     return json_decode($response->data, TRUE);
   }
@@ -1033,8 +1093,7 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
       $this->logger()->log(PersonalizeLogLevel::INFO, $success_msg, $vars);
     }
     else {
-      $this->logger()->log(PersonalizeLogLevel::ERROR, $fail_msg, $vars);
-      throw new AcquiaLiftException($fail_msg);
+      $this->handleBadResponse($response->code, $fail_msg, $vars);
     }
   }
 
@@ -1050,9 +1109,8 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
     }
     $response = $this->httpClient()->get($url, $headers);
     if ($response->code != 200) {
-      $msg = 'Problem retrieving targeting impact report.';
-      $this->logger()->log(PersonalizeLogLevel::ERROR, $msg);
-      throw new AcquiaLiftException($msg);
+      $this->handleBadResponse($response->code, 'Problem retrieving targeting impact report.');
+      return array();
     }
     return json_decode($response->data, TRUE);
   }
@@ -1066,9 +1124,8 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
     $url = $this->generateEndpoint("/report/status?codes={$codes}{$days}");
     $response = $this->httpClient()->get($url, array('Accept' => 'application/json'));
     if ($response->code != 200) {
-      $msg = 'Problem retrieving targeting impact report.';
-      $this->logger()->log(PersonalizeLogLevel::ERROR, $msg);
-      throw new AcquiaLiftException('Problem retrieving targeting impact report');
+      $this->handleBadResponse($response->code, 'Problem retrieving status report.');
+      return array();
     }
     return json_decode($response->data, TRUE);
   }
@@ -1104,9 +1161,8 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
     // Use a timeout of 8 seconds for retrieving the transform options.
     $response = $this->httpClient()->get($url, $headers);
     if ($response->code != 200) {
-      $msg = 'Problem retrieving confidence report.';
-      $this->logger()->log(PersonalizeLogLevel::ERROR, $msg);
-      throw new AcquiaLiftException($msg);
+      $this->handleBadResponse($response->code, 'Problem retrieving confidence report.');
+      return array();
     }
     return json_decode($response->data, TRUE);
   }
@@ -1132,9 +1188,8 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
     $response = $this->httpClient()->get($url, $headers);
 
     if ($response->code != 200) {
-      $msg = 'Problem retrieving learning report.';
-      $this->logger()->log(PersonalizeLogLevel::ERROR, $msg);
-      throw new AcquiaLiftException($msg);
+      $this->handleBadResponse($response->code, 'Problem retrieving learning report.');
+      return array();
     }
     return json_decode($response->data, TRUE);
   }
@@ -1154,9 +1209,8 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
     $headers = array('Accept' => 'application/json');
     $response = $this->httpClient()->get($url, $headers);
     if ($response->code != 200) {
-      $msg = 'Problem retrieving API call counts.';
-      $this->logger()->log(PersonalizeLogLevel::ERROR, $msg);
-      throw new AcquiaLiftException($msg);
+      $this->handleBadResponse($response->code, 'Problem retrieving API call counts.');
+      return array();
     }
     $result = json_decode($response->data, TRUE);
     if (!isset($result['data']) || !isset($result['data'][0]) || !isset($result['data'][0]['calls'])) {
@@ -1820,5 +1874,8 @@ class AcquiaLiftQueue extends SystemQueue {
 }
 
 class AcquiaLiftException extends Exception {}
-class AcquiaLiftNotFoundException extends AcquiaLiftException {}
+class AcquiaLiftServerErrorException extends AcquiaLiftException {}
+class AcquiaLiftClientErrorException extends AcquiaLiftException {}
+class AcquiaLiftNotFoundException extends AcquiaLiftClientErrorException {}
+class AcquiaLiftForbiddenException extends AcquiaLiftClientErrorException {}
 class AcquiaLiftCredsException extends AcquiaLiftException {}

--- a/includes/acquia_lift.classes.inc
+++ b/includes/acquia_lift.classes.inc
@@ -130,17 +130,30 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
    *
    * This is used during simpletest web tests.
    */
-  public static function setTestInstance($broken_http_client = FALSE) {
+  public static function setTestInstance($broken_http_client = FALSE, $simulate_client_side_breakage = FALSE) {
     module_load_include('inc', 'acquia_lift', 'tests/acquia_lift.test_classes');
     self::$instance = new self('test-api-key', 'test-admin-key', 'test-owner-code', 'http://api.example.com');
     // This method is only ever called within the context of a simpletest web
     // test, so the call to variable_get() is ok here.
     $test_data = variable_get('acquia_lift_web_test_data', array());
-    self::$instance->setHttpClient(new DummyAcquiaLiftHttpClient($broken_http_client, $test_data));
+    self::$instance->setHttpClient(new DummyAcquiaLiftHttpClient($broken_http_client, $test_data, $simulate_client_side_breakage));
     self::$instance->setLogger(new AcquiaLiftTestLogger(FALSE));
   }
 
-
+  /**
+   * Maps the passed in status code to one consumable by the Lift service.
+   *
+   * If the passed in status code is already a string status code that's
+   * consumable by Lift it just returns that code. If it's a numeric code
+   * defined in personalize module it maps it to the corresponding string
+   * code. If it's neither, an exception is thrown.
+   *
+   * @param $status
+   *   The status to map.
+   * @return string status
+   *   The status code consumable by Lift.
+   * @throws AcquiaLiftException
+   */
   public static function mapStatus($status) {
     $status_map = array(
       PERSONALIZE_STATUS_NOT_STARTED => self::PAUSED_STATUS,
@@ -457,9 +470,27 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
       $this->logger()->log(PersonalizeLogLevel::INFO, $success_msg, $vars);
     }
     else {
-      $this->logger()->log(PersonalizeLogLevel::ERROR, $fail_msg, $vars);
-      throw new AcquiaLiftException($fail_msg);
+      $this->handleBadResponse($response->code, $fail_msg, $vars);
     }
+  }
+
+  public function handleBadResponse($response_code, $fail_msg, $vars = array(), $log_failure = TRUE) {
+    if ($exception_class = self::mapBadResponseToExceptionClass($response_code)) {
+      if ($log_failure) {
+        $this->logger()->log(PersonalizeLogLevel::ERROR, $fail_msg, $vars);
+      }
+      throw new $exception_class($fail_msg);
+    }
+    if (self::isSuccessful($response_code)) {
+      // If the response wasn't actually bad but we still got here somehow, just
+      // log a warning and return.
+      if ($log_failure) {
+        $this->logger()->log(PersonalizeLogLevel::WARNING, $fail_msg, $vars);
+      }
+      return;
+    }
+    // Otherwise throw a generic exception.
+    throw new AcquiaLiftException($fail_msg);
   }
 
   /**
@@ -483,25 +514,6 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
     else {
       $this->handleBadResponse($response->code, $fail_msg, $vars);
     }
-  }
-
-  public function handleBadResponse($response_code, $fail_msg, $vars = array(), $log_failure = TRUE) {
-    if ($exception_class = self::mapBadResponseToExceptionClass($response_code)) {
-      if ($log_failure) {
-        $this->logger()->log(PersonalizeLogLevel::ERROR, $fail_msg, $vars);
-      }
-      throw new $exception_class($fail_msg);
-    }
-    if (self::isSuccessful($response_code)) {
-      // If the response wasn't actually bad but we still got here somehow, just
-      // log a warning and return.
-      if ($log_failure) {
-        $this->logger()->log(PersonalizeLogLevel::WARNING, $fail_msg, $vars);
-      }
-      return;
-    }
-    // Otherwise throw a generic exception.
-    throw new AcquiaLiftException($fail_msg);
   }
 
   /**
@@ -668,7 +680,8 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
       $this->logger()->log(PersonalizeLogLevel::INFO, $success_msg, $vars);
     }
     else {
-      $this->handleBadResponse($response->code, $fail_msg, $vars);
+      $this->logger()->log(PersonalizeLogLevel::ERROR, $fail_msg, $vars);
+      throw new AcquiaLiftException($fail_msg);
     }
   }
 

--- a/includes/acquia_lift.classes.inc
+++ b/includes/acquia_lift.classes.inc
@@ -20,6 +20,14 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
 
   const VALID_NAME_MATCH_PATTERN = '[A-Za-z0-9_-]';
 
+  const ENABLED_STATUS = 'enabled';
+
+  const PAUSED_STATUS = 'paused';
+
+  const STOPPED_STATUS = 'stopped';
+
+  const PROVISIONAL_STATUS = 'provisional';
+
   /**
    * The Acquia Lift API key to use.
    *
@@ -130,6 +138,25 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
     $test_data = variable_get('acquia_lift_web_test_data', array());
     self::$instance->setHttpClient(new DummyAcquiaLiftHttpClient($broken_http_client, $test_data));
     self::$instance->setLogger(new AcquiaLiftTestLogger(FALSE));
+  }
+
+
+  public static function mapStatus($status) {
+    $status_map = array(
+      PERSONALIZE_STATUS_NOT_STARTED => self::PAUSED_STATUS,
+      PERSONALIZE_STATUS_PAUSED => self::PAUSED_STATUS,
+      PERSONALIZE_STATUS_RUNNING => self::ENABLED_STATUS,
+      PERSONALIZE_STATUS_COMPLETED => self::STOPPED_STATUS
+    );
+    // Maybe we already have a Lift status string.
+    if (in_array($status, $status_map)) {
+      return $status;
+    }
+    // Otherwise map it to a Lift status.
+    if (!isset($status_map[$status])) {
+      throw new AcquiaLiftException('Unknown agent status: ' . $status);
+    }
+    return $status_map[$status];
   }
 
   /**
@@ -341,6 +368,37 @@ class AcquiaLiftAPI implements PersonalizeLoggerAwareInterface, AcquiaLiftReport
     $vars = array('agent' => $machine_name);
     $success_msg = 'The campaign {agent} was pushed to Acquia Lift';
     $fail_msg = 'The campaign {agent} could not be pushed to Acquia Lift';
+    if ($response->code == 200 && $data['status'] == 'ok') {
+      $this->logger()->log(PersonalizeLogLevel::INFO, $success_msg, $vars);
+    }
+    else {
+      $this->logger()->log(PersonalizeLogLevel::ERROR, $fail_msg, $vars);
+      throw new AcquiaLiftException($fail_msg);
+    }
+  }
+
+  /**
+   * Updates the status of an agent in Acquia Lift.
+   *
+   * @param $machine_name
+   *   The machine of the agent.
+   * @param $status
+   *   The status to set the agent to.
+   * @return boolean
+   *   TRUE if the agent has been saved to Acquia Lift, FALSE otherwise.
+   * @throws AcquiaLiftException
+   */
+  public function updateAgentStatus($machine_name, $status) {
+    $lift_status_code = self::mapStatus($status);
+    $url = $this->generateEndpoint("/agent-api/$machine_name");
+    $agent = array(
+      'status' => $lift_status_code,
+    );
+    $response = $this->httpClient()->put($url, array('Content-Type' => 'application/json; charset=utf-8', 'Accept' => 'application/json'), $agent);
+    $data = json_decode($response->data, TRUE);
+    $vars = array('agent' => $machine_name);
+    $success_msg = 'The new status of campaign {agent} was pushed to Acquia Lift';
+    $fail_msg = 'The new status of campaign {agent} could not be pushed to Acquia Lift';
     if ($response->code == 200 && $data['status'] == 'ok') {
       $this->logger()->log(PersonalizeLogLevel::INFO, $success_msg, $vars);
     }

--- a/plugins/agent_types/AcquiaLiftAgent.inc
+++ b/plugins/agent_types/AcquiaLiftAgent.inc
@@ -42,6 +42,11 @@ interface AcquiaLiftAgentInterface {
   public function syncFixedTargeting($option_sets);
 
   /**
+   * Syncs the agent's status to Acquia Lift.
+   */
+  public function syncAgentStatus();
+
+  /**
    * Organizes an array of option sets into decision points.
    *
    * @param $option_sets
@@ -491,7 +496,7 @@ class AcquiaLiftAgent extends PersonalizeAgentBase implements PersonalizeAgentGo
         $this->machineName,
         $this->title,
         $this->data['decision_style'],
-        'enabled',
+        $this->status,
         $acquia_lift_control_rate,
         $acquia_lift_explore_rate,
         isset($this->data['cache_decisions']) && $this->data['cache_decisions']
@@ -644,7 +649,7 @@ class AcquiaLiftAgent extends PersonalizeAgentBase implements PersonalizeAgentGo
       return $this->convertAgentExceptionToErrors($e, $errors);
     }
 
-    if ($acquia_lift_agent['status'] !== 'enabled') {
+    if ($acquia_lift_agent['status'] === AcquiaLiftAPI::PROVISIONAL_STATUS) {
       $errors[] = t('The status of the Acquia Lift agent is @status', array('@status' => $acquia_lift_agent['status']));
     }
     // Make sure Acquia Lift knows about the agent's goals.
@@ -864,6 +869,22 @@ class AcquiaLiftAgent extends PersonalizeAgentBase implements PersonalizeAgentGo
    */
   public function setQueue(DrupalQueueInterface $queue) {
     $this->queue = $queue;
+  }
+
+
+  /**
+   * Implements AcquiaLiftAgentInterface::syncAgentStatus().
+   */
+  public function syncAgentStatus() {
+    $items = array();
+    $items[] = array(
+      'method' => 'updateAgentStatus',
+      'args' => array(
+        $this->machineName,
+        $this->status,
+      ),
+    );
+    $this->queueItems($items);
   }
 
   /**

--- a/tests/AcquiaLiftAPI.test
+++ b/tests/AcquiaLiftAPI.test
@@ -701,7 +701,6 @@ class AcquiaLiftTest extends DrupalUnitTestCase {
     $lift_api = $this->getAcquiaLiftAPI();
 
     $machineName = 'some_machine_name';
-
     $lift_api->getAgent($machineName);
 
     // Define the requests we expect to have been made to our dummy http
@@ -1329,13 +1328,10 @@ class AcquiaLiftTest extends DrupalUnitTestCase {
 
     // Confirm the expected requests were made.
     $this->assertAPIRequests($requests);
-
     $logs = array();
-
     $this->assertLogs($logs);
 
     $lift_api = $this->getAcquiaLiftAPI(TRUE);
-
     try {
       $lift_api->getAgentStatusReport($agentNamesArray, $dayNumber);
     }
@@ -1349,7 +1345,7 @@ class AcquiaLiftTest extends DrupalUnitTestCase {
     $logs = array(
       array(
         'level' => PersonalizeLogLevel::ERROR,
-        'message' => 'Problem retrieving targeting impact report.',
+        'message' => 'Problem retrieving status report.',
       )
     );
 
@@ -1467,13 +1463,10 @@ class AcquiaLiftTest extends DrupalUnitTestCase {
 
     // Confirm the expected requests were made.
     $this->assertAPIRequests($requests);
-
     $logs = array();
-
     $this->assertLogs($logs);
 
     $lift_api = $this->getAcquiaLiftAPI(TRUE);
-
     try {
       $lift_api->getRawLearningReport($agentName, $startDate, $endDate);
     }
@@ -1518,6 +1511,7 @@ class AcquiaLiftTest extends DrupalUnitTestCase {
     );
     // Confirm the expected requests were made.
     $this->assertAPIRequests($requests);
+    DummyAcquiaLiftHttpClient::clearLoggedRequests();
     // Confirm the expected messages were logged.
     $logs = array(
       array(
@@ -1528,6 +1522,15 @@ class AcquiaLiftTest extends DrupalUnitTestCase {
     $this->assertLogs($logs);
     $this->logger->clearLogs();
 
+    // Make sure we can use a Personalize status code.
+    $this->assertAPIRequests(array());
+    $lift_api->saveAgent($agentName, 'Some Test Agent', 'adaptive', PERSONALIZE_STATUS_RUNNING);
+    // The requests and logs should be the same.
+    $this->assertAPIRequests($requests);
+    $this->assertLogs($logs);
+    $this->logger->clearLogs();
+
+    $this->assertAPIRequests(array());
     $lift_api->saveAgent($agentName, 'Some Test Agent', 'adaptive', 'enabled', 0.1, 0.4);
     // Define the requests we expect to have been made to our dummy http
     // client for this operation.
@@ -1894,6 +1897,93 @@ class AcquiaLiftTest extends DrupalUnitTestCase {
     $new_name = $lift_api->ensureUniqueAgentName('abcdefghijklmnopqrstuvwxyzabcdef', 32);
     $this->assertEqual('abcdefghijklmnopqrstuvwxyzabc-10', $new_name);
 
+  }
+
+
+  function testUpdateAgentStatus() {
+    $lift_api = $this->getAcquiaLiftAPI();
+    DummyAcquiaLiftHttpClient::clearLoggedRequests();
+    $agent_name = 'my-test-agent';
+    // The updating the status to a non-existent status code string.
+    try {
+      $lift_api->updateAgentStatus($agent_name, 'some-non-existent-status-code');
+      $this->fail('Exception not thrown as expected');
+    }
+    catch (Exception $e) {
+      $this->pass('Exception thrown as expected');
+    }
+
+    // Now try with a non-existent numeric code.
+    try {
+      $lift_api->updateAgentStatus($agent_name, 33);
+      $this->fail('Exception not thrown as expected');
+    }
+    catch (Exception $e) {
+      $this->pass('Exception thrown as expected');
+    }
+    // Now try with a string code that exists in Lift.
+    try {
+      $lift_api->updateAgentStatus($agent_name, AcquiaLiftAPI::PAUSED_STATUS);
+    }
+    catch (Exception $e) {
+      $this->fail('Exception thrown when none expected');
+    }
+    // Define the requests we expect to have been made to our dummy http
+    // client for this operation.
+    $requests = array(
+      array(
+        'type' => 'put',
+        'uri' => "http://api.lift.acquia.com/{$this->liftOwnerCode}/agent-api/$agent_name?apikey={$this->liftAdminKey}",
+        'headers' => array('Content-Type' => 'application/json; charset=utf-8', 'Accept' => 'application/json'),
+        'options' => array(),
+        'body' => array(
+          'status' => AcquiaLiftAPI::PAUSED_STATUS,
+        )
+      )
+    );
+    // Confirm the expected requests were made.
+    $this->assertAPIRequests($requests);
+    // Confirm the expected messages were logged.
+    $logs = array(
+      array(
+        'level' => PersonalizeLogLevel::INFO,
+        'message' => "The new status of campaign $agent_name was pushed to Acquia Lift",
+      )
+    );
+    $this->assertLogs($logs);
+    $this->logger->clearLogs();
+
+    // Now try with a numeric code that exists in Personalize.
+    try {
+      $lift_api->updateAgentStatus($agent_name, PERSONALIZE_STATUS_PAUSED);
+    }
+    catch (Exception $e) {
+      $this->fail('Exception thrown when none expected');
+    }
+
+    // The request made and the logs should be identical.
+    $this->assertAPIRequests($requests);
+    $this->assertLogs($logs);
+    $this->logger->clearLogs();
+
+    // Now try with a broken http client.
+    $lift_api = $this->getAcquiaLiftAPI(TRUE);
+    try {
+      $lift_api->updateAgentStatus($agent_name, PERSONALIZE_STATUS_PAUSED);
+      $this->fail('Exception not thrown as expected');
+    }
+    catch (Exception $e) {
+      $this->pass('Exception thrown as expected');
+    }
+    $this->assertAPIRequests($requests);
+    $logs = array(
+      array(
+        'level' => PersonalizeLogLevel::ERROR,
+        'message' => "The new status of campaign $agent_name could not be pushed to Acquia Lift",
+      )
+    );
+    $this->assertLogs($logs);
+    $this->logger->clearLogs();
   }
 
   /**

--- a/tests/acquia_lift.test
+++ b/tests/acquia_lift.test
@@ -142,7 +142,7 @@ class AcquiaLiftWebTestBase extends DrupalWebTestCase
           $data['machine_name'],
           $data['name'],
           'adaptive',
-          'enabled',
+          PERSONALIZE_STATUS_NOT_STARTED,
           isset($data['control_rate']) ? $data['control_rate'] / 100 : .1,
           isset($data['explore_rate']) ? ($data['explore_rate'] / 100) : .2,
           isset($data['cache_decisions']) && $data['cache_decisions']
@@ -780,7 +780,7 @@ class AcquiaLiftWebTestAgentAdmin extends AcquiaLiftWebTestBase {
             $machine_name,
             $agent_name,
             'adaptive',
-            'enabled',
+            PERSONALIZE_STATUS_NOT_STARTED,
             0.1,
             0.3,
             1
@@ -808,7 +808,7 @@ class AcquiaLiftWebTestAgentAdmin extends AcquiaLiftWebTestBase {
         $machine_name,
         $agent_name,
         'adaptive',
-        'enabled',
+        PERSONALIZE_STATUS_NOT_STARTED,
         0.1,
         0.3,
         1
@@ -825,7 +825,7 @@ class AcquiaLiftWebTestAgentAdmin extends AcquiaLiftWebTestBase {
           $machine_name,
           $agent_name,
           'adaptive',
-          'enabled',
+          PERSONALIZE_STATUS_NOT_STARTED,
           0.1,
           0.3,
           1
@@ -844,7 +844,7 @@ class AcquiaLiftWebTestAgentAdmin extends AcquiaLiftWebTestBase {
         $machine_name,
         $agent_name,
         'adaptive',
-        'enabled',
+        PERSONALIZE_STATUS_NOT_STARTED,
         0.1,
         0.3,
         1
@@ -909,7 +909,7 @@ class AcquiaLiftWebTestAgentAdmin extends AcquiaLiftWebTestBase {
           $agent->getMachineName(),
           $agent->getTitle(),
           $agentData['decision_style'],
-          'enabled',
+          PERSONALIZE_STATUS_NOT_STARTED,
           0.1,
           0.2,
           1
@@ -946,7 +946,7 @@ class AcquiaLiftWebTestAgentAdmin extends AcquiaLiftWebTestBase {
           $agent->getMachineName(),
           $agent->getTitle(),
           $agentData['decision_style'],
-          'enabled',
+          PERSONALIZE_STATUS_NOT_STARTED,
           0.1,
           0.2,
           1
@@ -1003,7 +1003,7 @@ class AcquiaLiftWebTestAgentAdmin extends AcquiaLiftWebTestBase {
         $agent->getMachineName(),
         $agent->getTitle(),
         $agentData['decision_style'],
-        'enabled',
+        PERSONALIZE_STATUS_NOT_STARTED,
         ($agentData['control_rate'] / 100),
         ($agentData['explore_rate'] / 100),
         isset($agentData['cache_decisions']) && $agentData['cache_decisions']
@@ -1226,7 +1226,7 @@ class AcquiaLiftWebTestAgentAdmin extends AcquiaLiftWebTestBase {
           $agent->getMachineName(),
           $agent->getTitle(),
           'adaptive',
-          'enabled',
+          PERSONALIZE_STATUS_NOT_STARTED,
           0.1,
           0.2,
           1
@@ -1307,7 +1307,7 @@ class AcquiaLiftWebTestAgentAdmin extends AcquiaLiftWebTestBase {
           $agent->getMachineName(),
           $agent->getTitle(),
           'adaptive',
-          'enabled',
+          PERSONALIZE_STATUS_NOT_STARTED,
           0.1,
           0.2,
           1
@@ -1348,7 +1348,7 @@ class AcquiaLiftWebTestAgentAdmin extends AcquiaLiftWebTestBase {
           $agent->getMachineName(),
           $agent->getTitle(),
           'adaptive',
-          'enabled',
+          PERSONALIZE_STATUS_NOT_STARTED,
           0.1,
           0.2,
           1
@@ -1378,7 +1378,7 @@ class AcquiaLiftWebTestAgentAdmin extends AcquiaLiftWebTestBase {
 //          $agent->getMachineName(),
 //          $agent->getTitle(),
 //          'adaptive',
-//          'enabled',
+//          PERSONALIZE_STATUS_NOT_STARTED,
 //           0,
 //        ),
 //      ),
@@ -1395,6 +1395,30 @@ class AcquiaLiftWebTestAgentAdmin extends AcquiaLiftWebTestBase {
 
   public function testDeleteAgentGoals() {
     // @todo implement or remove it after goal deletion decision
+  }
+
+  public function testUpdateAgentStatus() {
+    $agent = $this->createTestAgent();
+    $agent_name = $agent->getMachineName();
+    // Manually set the agent's status to running, bypassing the verification check.
+    variable_set(_personalize_agent_get_status_variable($agent_name), PERSONALIZE_STATUS_RUNNING);
+    $this->resetAll();
+    // Now use the API function to update the status.
+    personalize_agent_set_status($agent_name, PERSONALIZE_STATUS_PAUSED);
+
+    $expected_queues = array(
+      array(
+        'method' => 'updateAgentStatus',
+        'args' => array(
+          $agent_name,
+          PERSONALIZE_STATUS_PAUSED,
+        ),
+      ),
+    );
+
+    $this->assertQueueItems($expected_queues);
+    $this->personalizedQueue->deleteQueue();
+
   }
 }
 class AcquiaLiftWebTestFundamentals extends AcquiaLiftWebTestBase {
@@ -1425,7 +1449,7 @@ class AcquiaLiftWebTestFundamentals extends AcquiaLiftWebTestBase {
         $machine_name,
         $agent_name,
         'adaptive',
-        'enabled',
+        PERSONALIZE_STATUS_NOT_STARTED,
         0.1,
         0.2,
         1
@@ -1498,6 +1522,41 @@ class AcquiaLiftWebTestFundamentals extends AcquiaLiftWebTestBase {
       );
     }
     $test_logger = new AcquiaLiftTestLogger(FALSE);
+    $logs = $test_logger->getLogs();
+    $this->assertEqual($expected_logs, $logs);
+    // Item should be removed after final attempt.
+    $this->assertQueueItems(array());
+    $test_logger->clearLogs();
+
+    // Edit the agent again.
+    $edit = array(
+      'cache_decisions' => FALSE
+    );
+    $this->drupalPost("admin/structure/personalize/manage/$machine_name/edit", $edit, $this->getButton('agent'));
+    personalize_agent_set_status($machine_name, PERSONALIZE_STATUS_PAUSED);
+    $this->resetAll();
+    $queued_agent_item['args'][6] = FALSE;
+    $expected_queue_items = array($queued_agent_item);
+    $expected_queue_items[] = array(
+      'method' => 'updateAgentStatus',
+      'args' => array(
+        $machine_name,
+        PERSONALIZE_STATUS_PAUSED,
+      ),
+    );
+    $this->assertQueueItems($expected_queue_items);
+    $this->resetAll();
+    // Cause the queue to fail based on a bad request. There should not be any retries,
+    // it should just be aborted.
+    AcquiaLiftAPI::setTestInstance(TRUE, TRUE); // 2nd param specifies simulating client-side error, i.e. 400 error.
+    // Run the queue.
+    $_SESSION['acquia_lift_queue_trigger'] = true;
+    acquia_lift_process_queue(FALSE);
+    $expected_logs = array();
+    $expected_logs[] = array(
+      'level' => 'error',
+      'message' => "The campaign $machine_name could not be pushed to Acquia Lift",
+    );
     $logs = $test_logger->getLogs();
     $this->assertEqual($expected_logs, $logs);
     // Item should be removed after final attempt.
@@ -1652,7 +1711,7 @@ class AcquiaLiftWebTestFundamentals extends AcquiaLiftWebTestBase {
             'first-existing-agent',
             'first-existing-agent',
             'adaptive',
-            'enabled',
+            PERSONALIZE_STATUS_NOT_STARTED,
             $control_rate / 100,
             $explore_rate / 100,
             TRUE,
@@ -2199,7 +2258,7 @@ class AcquiaLiftWebTestWorkflow extends AcquiaLiftWebTestBase {
           'article-personalizable-headline',
           'Article: Personalizable Headline 1',
           'adaptive',
-          'enabled',
+          PERSONALIZE_STATUS_NOT_STARTED,
           10/100,
           25/100,
           true
@@ -2321,7 +2380,7 @@ class AcquiaLiftWebTestWorkflow extends AcquiaLiftWebTestBase {
           'article-personalizable-headline-2',
           'Article: Personalizable Headline 2',
           'adaptive',
-          'enabled',
+          PERSONALIZE_STATUS_NOT_STARTED,
           10/100,
           25/100,
           true

--- a/tests/acquia_lift.test_classes.inc
+++ b/tests/acquia_lift.test_classes.inc
@@ -24,6 +24,13 @@ class DummyAcquiaLiftHttpClient implements AcquiaLiftDrupalHttpClientInterface {
    */
   protected $broken;
 
+    /**
+     * The type of breakage to simulate, i.e. client or server side.
+     *
+     * @var string
+     */
+  protected $breakageType;
+
   /**
    * An array of data simulating resources than can be returned.
    *
@@ -41,8 +48,18 @@ class DummyAcquiaLiftHttpClient implements AcquiaLiftDrupalHttpClientInterface {
    */
   protected function generateDummyResponse($data) {
     $response = new stdClass();
-    $response->code = $this->broken ? 500 : 200;
-    $response->status_message = $this->broken ? "Internal Server Error" : "OK";
+    $response->code = 200;
+    $response->status_message = 'OK';
+    if ($this->broken) {
+      if ($this->breakageType == 'client') {
+        $response->code = 400;
+        $response->status_message = 'Bad request';
+      }
+      else {
+        $response->code = 500;
+        $response->status_message = 'Internal Server Error';
+      }
+    }
     $response->data = drupal_json_encode($data);
     return $response;
   }
@@ -55,8 +72,9 @@ class DummyAcquiaLiftHttpClient implements AcquiaLiftDrupalHttpClientInterface {
    * @param array $data
    *   An array of dummy data that can be returned in responses.
    */
-  public function __construct($broken = FALSE, $data = array()) {
+  public function __construct($broken = FALSE, $data = array(), $simulate_client_side_breakage = FALSE) {
     $this->broken = $broken;
+    $this->breakageType = $simulate_client_side_breakage ? 'client' : 'server';
     $this->data += $data;
   }
 


### PR DESCRIPTION
I ended up doing a lot of work on how we handle bad responses from Lift as part of this story. The main reason for doing this was to allow the queue to be aborted if a certain type of exception is thrown. If we are making a bad request that Lift cannot handle, then the queue should not proceed to the next item, which could be setting the status to running. Instead the user should get a message that something went wrong.
