### PR TITLE
Ch 1703: Don't show report charts/tables when decisions hasn't been shown.

### DIFF
--- a/acquia_lift.admin.inc
+++ b/acquia_lift.admin.inc
@@ -423,7 +423,7 @@ function acquia_lift_report_custom($form, &$form_state, $agent, $agent_data, $op
     // This campaign hasn't been shown yet, so there is no data for reporting.
     return array(
       'no_report' => array(
-        '#markup' => t('This campaign has not been shown yet so there is no report data available.  Check back here after the campaign has been shown to site visitors.'),
+        '#markup' => t('This campaign does not yet contain information about your visitors\' website interactions. This situation generally occurs for campaigns that have either just been started or do not generate much website traffic.'),
       ),
     );
   }
@@ -806,7 +806,7 @@ function acquia_lift_report_ab($form, &$form_state, $agent, $agent_data) {
     // This campaign hasn't been shown yet, so there is no data for reporting.
     return array(
       'no_report' => array(
-        '#markup' => t('This campaign has not been shown yet so there is no report data available.  Check back here after the campaign has been shown to site visitors.'),
+        '#markup' => t('This campaign does not yet contain information about your visitors\' website interactions. This situation generally occurs for campaigns that have either just been started or do not generate much website traffic.'),
       ),
     );
   }

--- a/acquia_lift.admin.inc
+++ b/acquia_lift.admin.inc
@@ -419,6 +419,14 @@ function acquia_lift_report_custom($form, &$form_state, $agent, $agent_data, $op
   );
 
   $reports = $agent->buildCampaignReports($options);
+  if (!($reports['#has_data'])) {
+    // This campaign hasn't been shown yet, so there is no data for reporting.
+    return array(
+      'no_report' => array(
+        '#markup' => t('This campaign has not been shown yet so there is no report data available.  Check back here after the campaign has been shown to site visitors.'),
+      ),
+    );
+  }
 
   // Generate mark-up for adaptive style report labels.
   $report_title_additional = '';
@@ -793,6 +801,16 @@ function acquia_lift_report_ab($form, &$form_state, $agent, $agent_data) {
     'end' => $date_end_report,
   );
   $build['reports'] = $agent->buildCampaignReports($options);
+
+  if (!$build['reports']['#has_data']) {
+    // This campaign hasn't been shown yet, so there is no data for reporting.
+    return array(
+      'no_report' => array(
+        '#markup' => t('This campaign has not been shown yet so there is no report data available.  Check back here after the campaign has been shown to site visitors.'),
+      ),
+    );
+  }
+
   $build['reports']['#attached']['library'][] = array('acquia_lift', 'acquia_lift.reports');
 
   return $build;

--- a/plugins/agent_types/AcquiaLiftAgent.inc
+++ b/plugins/agent_types/AcquiaLiftAgent.inc
@@ -1626,6 +1626,50 @@ abstract class AcquiaLiftReportBase implements PersonalizeAgentReportInterface, 
   }
 
   /**
+   * Extracts the required overview data from the report data returned by
+   * Acquia Lift.
+   *
+   * @param $items
+   *   An array of items as returned from Acquia Lift.
+   * @return array
+   *   An associative array with information for today's and the total overview.
+   */
+  protected function extractOverviewReportData($items) {
+    $agent_data = $this->agent->getData();
+    $decision_style = $agent_data['decision_style'] === 'adaptive' ? t('Auto-personalize') : t('A/B');
+    $total_variations = count($agent_data['decisions']);
+
+    // Create an array of data for each time option.
+    $report['today'] = array(
+      'unformatted' => array(
+        'total_lift' => $items['today']['liftOverDefaultUsingGoals'],
+        'total_shown' => $items['today']['sessionCount'],
+        'total_goals' => $items['today']['goalCount'],
+      ),
+      'test_type' => $decision_style,
+      'total_shown' => $this->formatReportNumber($items['today']['sessionCount']),
+      'total_goals' => $this->formatReportNumber($items['today']['goalCount']),
+      'total_goals_positive' => $items['today']['goalCount'] > 0,
+      'total_lift' => $this->formatReportPercentage($items['today']['liftOverDefaultUsingGoals']),
+      'total_variations' => $total_variations,
+    );
+    $report['all'] = array(
+      'unformatted' => array(
+        'total_shown' => $items['totals']['sessions']['count'],
+        'total_goals' => $items['totals']['goals']['count'],
+        'total_lift' => $items['today']['liftOverDefaultUsingGoalsToDate'],
+      ),
+      'test_type' => $decision_style,
+      'total_shown' => $this->formatReportNumber($items['totals']['sessions']['count']),
+      'total_goals' => $this->formatReportNumber($items['totals']['goals']['count']),
+      'total_goals_positive' => $items['totals']['goals']['count'] > 0,
+      'total_lift' => $this->formatReportPercentage($items['today']['liftOverDefaultUsingGoalsToDate']),
+      'total_variations' => $total_variations,
+    );
+    return $report;
+  }
+
+  /**
    * Extracts data from the raw confidence detail report that is prepared for use
    * within the conversion report rendering process.
    *
@@ -2051,12 +2095,35 @@ class AcquiaLiftABReport extends AcquiaLiftReportBase {
   }
 
   /**
+   * Generates report overview data.
+   */
+  public function generateOverviewData(&$report_data) {
+    $this->loadAgentStatusData($report_data);
+    $report_data['status'] = $report = $this->extractOverviewReportData($report_data['raw']['status']['data'][$report_data['machine_name']]);
+    if ($report === FALSE) {
+      return array();
+    }
+
+    if ($report_data['today_only']) {
+      $overview_report = $report_data['status']['today'];
+    }
+    else {
+      $overview_report = $report_data['status']['all'];
+    }
+    $report_data['has_data'] = $overview_report['total_shown'] > 0;
+    return $report_data;
+  }
+
+  /**
    * Implements PersonalizeAgentReportInterface::buildCampaignReports().
    */
   public function buildCampaignReports($options) {
     $report_data = $this->generateReportConfiguration($options);
     $this->loadConversionReportData($report_data);
-    return $this->buildAllConversionReports($report_data);
+    $this->generateOverviewData($report_data);
+    $reports = $this->buildAllConversionReports($report_data);
+    $reports['#has_data'] = $report_data['has_data'];
+    return $reports;
   }
 }
 
@@ -2127,10 +2194,12 @@ class AcquiaLiftReport extends AcquiaLiftReportBase {
       'stability' => $this->buildStabilityReport($report_data),
       'targeting' => $this->buildReportContextSelection($report_data),
     );
+    $reports['#has_data'] = $reports['overview']['shown']['#title'] > 0;
+
     if (!is_array($report_data['status']) || !is_array($report_data['confidence']) || !is_array($report_data['targeting']) || !is_array($report_data['potential_context'])) {
       drupal_set_message(t('There was a problem retrieving the report data.  Please try again later.'), 'error');
     }
-    else if ($report_data['status']['all']['total_confident'] == 0) {
+    else if ($reports['#has_data'] && $report_data['status']['all']['total_confident'] == 0) {
       drupal_set_message($this->getLowConfidenceMessage(), 'warning');
     }
     return $reports;
@@ -2569,50 +2638,6 @@ class AcquiaLiftReport extends AcquiaLiftReportBase {
       '#options' => $context_values,
       '#multiple' => TRUE,
     );
-  }
-
-  /**
-   * Extracts the required overview data from the report data returned by
-   * Acquia Lift.
-   *
-   * @param $items
-   *   An array of items as returned from Acquia Lift.
-   * @return array
-   *   An associative array with information for today's and the total overview.
-   */
-  protected function extractOverviewReportData($items) {
-    $agent_data = $this->agent->getData();
-    $decision_style = $agent_data['decision_style'] === 'adaptive' ? t('Auto-personalize') : t('A/B');
-    $total_variations = count($agent_data['decisions']);
-
-    // Create an array of data for each time option.
-    $report['today'] = array(
-      'unformatted' => array(
-        'total_lift' => $items['today']['liftOverDefaultUsingGoals'],
-        'total_shown' => $items['today']['sessionCount'],
-        'total_goals' => $items['today']['goalCount'],
-      ),
-      'test_type' => $decision_style,
-      'total_shown' => $this->formatReportNumber($items['today']['sessionCount']),
-      'total_goals' => $this->formatReportNumber($items['today']['goalCount']),
-      'total_goals_positive' => $items['today']['goalCount'] > 0,
-      'total_lift' => $this->formatReportPercentage($items['today']['liftOverDefaultUsingGoals']),
-      'total_variations' => $total_variations,
-    );
-    $report['all'] = array(
-      'unformatted' => array(
-        'total_shown' => $items['totals']['sessions']['count'],
-        'total_goals' => $items['totals']['goals']['count'],
-        'total_lift' => $items['today']['liftOverDefaultUsingGoalsToDate'],
-      ),
-      'test_type' => $decision_style,
-      'total_shown' => $this->formatReportNumber($items['totals']['sessions']['count']),
-      'total_goals' => $this->formatReportNumber($items['totals']['goals']['count']),
-      'total_goals_positive' => $items['totals']['goals']['count'] > 0,
-      'total_lift' => $this->formatReportPercentage($items['today']['liftOverDefaultUsingGoalsToDate']),
-      'total_variations' => $total_variations,
-    );
-    return $report;
   }
 
   /**

--- a/plugins/agent_types/AcquiaLiftAgent.inc
+++ b/plugins/agent_types/AcquiaLiftAgent.inc
@@ -1637,7 +1637,7 @@ abstract class AcquiaLiftReportBase implements PersonalizeAgentReportInterface, 
   protected function extractOverviewReportData($items) {
     $agent_data = $this->agent->getData();
     $decision_style = $agent_data['decision_style'] === 'adaptive' ? t('Auto-personalize') : t('A/B');
-    $total_variations = count($agent_data['decisions']);
+    $total_variations = isset($agent_data['decisions']) ? count($agent_data['decisions']) : 0;
 
     // Create an array of data for each time option.
     $report['today'] = array(
@@ -2296,9 +2296,11 @@ class AcquiaLiftReport extends AcquiaLiftReportBase {
 
     // Determine overall confidence based on confidence in choices.
     $total_confident = 0;
-    foreach($report_data['confidence']['features'][self::NO_FEATURES] as $choice) {
-      if ($choice['significant']) {
-        $total_confident++;
+    if (isset($report_data['confidence']['features'][self::NO_FEATURES])) {
+      foreach ($report_data['confidence']['features'][self::NO_FEATURES] as $choice) {
+        if ($choice['significant']) {
+          $total_confident++;
+        }
       }
     }
 
@@ -2317,47 +2319,49 @@ class AcquiaLiftReport extends AcquiaLiftReportBase {
 
     // Update context report data.
     $option_numbers = array();
-    foreach ($report_data['confidence']['features'] as $feature_string => $feature) {
-      // Get the user-friendly feature label from the possible contextual values.
-      $feature_label = $feature_string;
-      if (isset($report_data['potential_context'][$feature_string])) {
-        $feature_label = $report_data['potential_context'][$feature_string]['label'];
-      }
+    if (isset($report_data['confidence']['features'])) {
+      foreach ($report_data['confidence']['features'] as $feature_string => $feature) {
+        // Get the user-friendly feature label from the possible contextual values.
+        $feature_label = $feature_string;
+        if (isset($report_data['potential_context'][$feature_string])) {
+          $feature_label = $report_data['potential_context'][$feature_string]['label'];
+        }
 
-      // This report only shows features that can be targeted.
-      if (!isset($report_data['targeting'][$feature_string])) {
-        continue;
-      }
+        // This report only shows features that can be targeted.
+        if (!isset($report_data['targeting'][$feature_string])) {
+          continue;
+        }
 
-      // Get the data from the targeting report for this feature.
-      $targeting_data = $report_data['targeting'][$feature_string];
+        // Get the data from the targeting report for this feature.
+        $targeting_data = $report_data['targeting'][$feature_string];
 
-      // Create a hash of choice numbers for stability report.
-      // Don't show system-defined features.
-      if ($targeting_data['system'] === TRUE) {
-        continue;
-      }
-      foreach($feature as $choice_id => $choice) {
-        $report_data['context']['features'][$feature_string][$choice_id] = array(
-          'counter' => $choice['counter'],
-          'choice_id' => $choice['choice_id'],
-          'best' => ($isAdaptive && $targeting_data['favored_selection'] === $choice['raw_label']),
-          'decisions' => $choice['decisions'],
-          'lift_default' => $choice['control'] ? self::DATA_NA : $choice['lift_default'],
-          'lift_default_positive' => $choice['unformatted']['lift_default'] > self::LIFT_THRESHHOLD,
-          'lift_random' => $choice['lift_random'],
-          'lift_random_positive' => $choice['unformatted']['lift_random'] > self::LIFT_THRESHHOLD,
-          'control' => $choice['control'],
-          'feature_label' => $feature_label,
-          'goals' => $choice['goals'],
-          'conversion' => $choice['conversion'],
-        );
-        $option_numbers[$feature_string . '|' . $choice['raw_label']] = $choice['counter'];
+        // Create a hash of choice numbers for stability report.
+        // Don't show system-defined features.
+        if ($targeting_data['system'] === TRUE) {
+          continue;
+        }
+        foreach ($feature as $choice_id => $choice) {
+          $report_data['context']['features'][$feature_string][$choice_id] = array(
+            'counter' => $choice['counter'],
+            'choice_id' => $choice['choice_id'],
+            'best' => ($isAdaptive && $targeting_data['favored_selection'] === $choice['raw_label']),
+            'decisions' => $choice['decisions'],
+            'lift_default' => $choice['control'] ? self::DATA_NA : $choice['lift_default'],
+            'lift_default_positive' => $choice['unformatted']['lift_default'] > self::LIFT_THRESHHOLD,
+            'lift_random' => $choice['lift_random'],
+            'lift_random_positive' => $choice['unformatted']['lift_random'] > self::LIFT_THRESHHOLD,
+            'control' => $choice['control'],
+            'feature_label' => $feature_label,
+            'goals' => $choice['goals'],
+            'conversion' => $choice['conversion'],
+          );
+          $option_numbers[$feature_string . '|' . $choice['raw_label']] = $choice['counter'];
+        }
       }
     }
 
     // Build the experiment report data
-    $report_data['experiment']['choices'] = $report_data['confidence']['features'][self::NO_FEATURES];
+    $report_data['experiment']['choices'] = isset($report_data['confidence']['features'][self::NO_FEATURES]) ? $report_data['confidence']['features'] : array();
 
     // Build the stability report data
     foreach ($report_data['targeting'] as $feature_string => &$feature) {

--- a/tests/acquia_lift.test
+++ b/tests/acquia_lift.test
@@ -2200,6 +2200,14 @@ class AcquiaLiftWebTestReports extends AcquiaLiftWebTestBase {
       $started = time();
       $agent->started = $started;
       personalize_agent_save($agent);
+
+      $report_start_date = 1407499650;
+      // Test to ensure that an initial report at this point returns no data.
+      AcquiaLiftAPI::setTestInstance();
+      $agent_instance = personalize_agent_load_agent($first_agent);
+      $report = $agent_instance->buildCampaignReports(array('decision' => 'osid-' . $option_sets[0]->osid, 'start' => $report_start_date));
+      $this->assertFalse($report['#has_data'], 'Report has no data.');
+
       // Add some test data so that calls to get reports for this agent will
       // return basic reports.
       $test_data = array_merge_recursive($test_data, array(
@@ -2252,10 +2260,8 @@ class AcquiaLiftWebTestReports extends AcquiaLiftWebTestBase {
     $this->resetAll();
 
     // We use the date that the test report was created.
-    $report_start_date = 1407499650;
-    AcquiaLiftAPI::setTestInstance();
-    $agent_instance = personalize_agent_load_agent($first_agent);
     $report = $agent_instance->buildCampaignReports(array('decision' => 'osid-' . $option_sets[0]->osid, 'start' => $report_start_date));
+    $this->assertTrue($report['#has_data'], 'Report now reports having data.');
 
     // The experiment report should show that Option A has a 0% conversion rate.
     $this->assertEqual("Option A", $report['experiment']['reports']['conversion']['reports']['summary']['summary_holder']['summary_table']['#rows'][0]['data'][0]['data']);

--- a/tests/acquia_lift.test
+++ b/tests/acquia_lift.test
@@ -1480,7 +1480,6 @@ class AcquiaLiftWebTestAgentAdmin extends AcquiaLiftWebTestBase {
     $this->personalizedQueue->deleteQueue();
 
     $goals = personalize_goal_load_by_conditions(array('agent' => $agent_name));
-    debug($goals);
     $this->assertEqual(2, count($goals));
     $goal_ids = array_keys($goals);
     $first_goal_id = $goal_ids[0];
@@ -2258,10 +2257,12 @@ class AcquiaLiftWebTestReports extends AcquiaLiftWebTestBase {
     }
     variable_set('acquia_lift_web_test_data', $test_data);
     $this->resetAll();
+    AcquiaLiftAPI::setTestInstance();
+    $agent_instance = personalize_agent_load_agent($first_agent);
 
     // We use the date that the test report was created.
     $report = $agent_instance->buildCampaignReports(array('decision' => 'osid-' . $option_sets[0]->osid, 'start' => $report_start_date));
-    $this->assertTrue($report['#has_data'], 'Report now reports having data.');
+    $this->assertFalse($report['#has_data'], 'Empty reports have no data to show.');
 
     // The experiment report should show that Option A has a 0% conversion rate.
     $this->assertEqual("Option A", $report['experiment']['reports']['conversion']['reports']['summary']['summary_holder']['summary_table']['#rows'][0]['data'][0]['data']);
@@ -2282,6 +2283,7 @@ class AcquiaLiftWebTestReports extends AcquiaLiftWebTestBase {
     variable_set("acquia_lift_report_source_$first_agent", "/" . $path . '/tests/test_reports.json');
     $agent_instance = personalize_agent_load_agent($first_agent);
     $report = $agent_instance->buildCampaignReports(array('decision' => 'osid-' . $option_sets[0]->osid, 'start' => $report_start_date));
+    $this->assertTrue($report['#has_data'], 'Report data file indicates data to show.');
 
     // Now the experiment report should show that Option A has a conversion rate of .19%
     $this->assertEqual("osid-76:Option A", $report['experiment']['reports']['conversion']['reports']['summary']['summary_holder']['summary_table']['#rows'][0]['data'][0]['data']);
@@ -2291,6 +2293,7 @@ class AcquiaLiftWebTestReports extends AcquiaLiftWebTestBase {
     // The report for the second agent should still show the basic report data.
     $agent_instance = personalize_agent_load_agent($second_agent);
     $report = $agent_instance->buildCampaignReports(array('decision' => 'osid-' . $option_sets[0]->osid, 'start' => $report_start_date));
+    $this->assertFalse($report['#has_data'], 'Empty report data still indicates no data to show.');
     $this->assertEqual("Option A", $report['experiment']['reports']['conversion']['reports']['summary']['summary_holder']['summary_table']['#rows'][0]['data'][0]['data']);
     $this->assertEqual("Control", $report['experiment']['reports']['conversion']['reports']['summary']['summary_holder']['summary_table']['#rows'][0]['data'][0]['data-acquia-lift-variation-label']);
     $this->assertEqual("0%", $report['experiment']['reports']['conversion']['reports']['summary']['summary_holder']['summary_table']['#rows'][0]['data'][2]['data']);


### PR DESCRIPTION
Note: the two overview report function chunks are just moving the functions from the Lift report class down to the base class for use with both lift report types.
