### PR TITLE
Ch 2308 Fix and stablize behat tests.

### DIFF
--- a/behat-tests/README.txt
+++ b/behat-tests/README.txt
@@ -22,27 +22,11 @@ To set up your environment to run tests locally:
     - Navigate to the behat-tests folder
     - Type: composer install
 
-5.  Copy behat.template.yml and rename it to behat.yml
+5.  Copy behat.template.yml and rename it to behat.yml.
 
 6.  Update behat.yml settings to match your environment.  You will need to at least adjust base_url and
     drupal_root. Additionally you can copy over any setting from behat.common.yml and change it to match
     your configuration such as a different CSS selector for a particular region.
-
-7.  Create the following Drupal roles:
-    Marketer:  This role should have the ability to manage personalized content
-    as well as to see the administration menus.  Specifically:
-    - Manage personalized content
-    - Use the administration pages and help
-    - Use the administration toolbar
-    - Administer visitor actions
-    Nonmarketer:  This role should have the ability to see administration menus.
-    Specifically:
-    - Use the administration pages and help
-    - Use the administration toolbar
-    But not:
-    - Manage personalized content
-
-    @todo: Add this role creation into the before/after hooks.
 
 To run tests:
 

--- a/behat-tests/behat.template.yml
+++ b/behat-tests/behat.template.yml
@@ -4,7 +4,7 @@ imports:
 default:
   extensions:
     Behat\MinkExtension:
-      base_url: http://localurl
+      base_url: 'http://localurl'
     Drupal\DrupalExtension:
       drupal:
         drupal_root: '/Path/to/Drual/Webroot'

--- a/behat-tests/features/acquia_lift_element_variations.feature
+++ b/behat-tests/features/acquia_lift_element_variations.feature
@@ -63,6 +63,7 @@ Feature: Personalize elements variations can be edited for an existing campaign.
     When I click "Add variation" in the "lift_tray" region
     Then I should see "#page-title" element in the "page_content" region is "highlighted" for editing
     And I should see the text "Edit text: <H1>" in the "dialog_variation_type_form" region
+    And the "personalize_elements_content" field should contain "Test Article Title - Updated 1"
     And I should not see the link "Edit selector" in the "dialog_variation_type_form" region
     When I fill in "Test Article Title - Updated 2" for "personalize_elements_content"
     And I click "#edit-variation-type-submit-form" element in the "dialog_variation_type_form" region

--- a/behat-tests/features/acquia_lift_element_variations.feature
+++ b/behat-tests/features/acquia_lift_element_variations.feature
@@ -1,25 +1,32 @@
-#Assumes Marketer role.
+@api @javascript @insulated @campaign
 Feature: Personalize elements variations can be edited for an existing campaign.
   In order to manage element variations in context
   As a site marketer
   I want the ability to add, edit, and delete existing personalize element variations in context.
 
-  @api @javascript @campaign
   Scenario: Add personalize elements to a campaign
+    # I have a campaign.
+    # I login with the marketer role.
+    # I am on an article page.
     Given "acquia_lift" agents:
-      | machine_name                    | label |
+      | machine_name                    | label                           |
       | testing-campaign-add-variations | Testing campaign add variations |
-    And I am logged in as a user with the "Marketer" role
+    And I am logged in as a user with the "access administration pages,access toolbar,administer visitor actions,manage personalized content" permission
+    And I am on the homepage
     And I am viewing an "Article" content:
-      | title | My article title |
-      | body  | A placeholder           |
+      | title | Test Article Title - Original |
     When I click "Acquia Lift" in the "menu" region
     And I wait for AJAX to finish
     Then I should see the link "Campaigns" in the "lift_tray" region
+
+    # I open the variation set's menu.
     When I hover over "Campaigns" in the "lift_tray" region
     And I click "Testing campaign add variations" in the "lift_tray" region
-    Then I should see the link "Variation Sets" visible in the "lift_tray" region
+    And I wait for AJAX to finish
+    Then I should visibly see the link "Variation Sets" in the "lift_tray" region
     And I should see "0" for the "variation set" count
+
+    # I bring up the "Add variation set" interface.
     When I hover over "Variation Sets" in the "lift_tray" region
     Then I should see the link "Add variation set" in the "lift_tray" region
     Then I should see the link "All variation sets" in the "lift_tray" region
@@ -31,6 +38,8 @@ Feature: Personalize elements variations can be edited for an existing campaign.
     When I click "Webpage elements" in the "modal_content" region
     And I wait for AJAX to finish
     Then I should not see the modal
+
+    # I add a new variation set.
     When I click "#page-title" element in the "page_content" region
     And I wait for AJAX to finish
     Then I should see the text "<H1>" in the "dialog_variation_type" region
@@ -38,64 +47,80 @@ Feature: Personalize elements variations can be edited for an existing campaign.
     And I wait for AJAX to finish
     Then I should not see the variation type dialog
     And I should see the text "Edit text: <H1>" in the "dialog_variation_type_form" region
-    And the "personalize_elements_content" field should contain "My article title"
-    When I fill in "Test 1" for "personalize_elements_content"
+    When I fill in "Test Article Title - Updated 1" for "personalize_elements_content"
     And I fill in "Test variation set" for "title"
-    And I press the "Save" button
+    And I click "#edit-variation-type-submit-form" element in the "dialog_variation_type_form" region
     And I wait for AJAX to finish
+
+    # I verify my variation set is created.
     Then I should see the message "The variation set has been created." in the messagebox
     When I wait for AJAX to finish
     Then I should not see the variation type form dialog
-    And I should see the text "Test 1" in the "page_content" region
+    And I should see the text "Test Article Title" in the "page_content" region
     And I should see "1" for the "variation set" count
+
+    # I bring up the "Add variation" interface.
     When I hover over "Variation Sets" in the "lift_tray" region
     Then I should see the text "Test variation set" in the "lift_tray" region
     And I should see the link "Control variation" in the "lift_tray" region
     And I should see the link "Variation #1" in the "lift_tray" region
     And I should see the link "Add variation" in the "lift_tray" region
     And I should see the link "Add variation set" in the "lift_tray" region
+
+    # I add a new variation to to the existing variation set.
     When I click "Add variation" in the "lift_tray" region
     Then "#page-title" element in the "page_content" region should have "acquia-lift-page-variation-item" class
-    And I should see the text "Edit HTML: <H1>" in the "dialog_variation_type_form" region
-    And I should not see the link "Edit selector" visible in the "dialog_variation_type_form" region
-    When I fill in "Test 2" for "personalize_elements_content"
-    And I press the "Save" button
+    And I should see the text "Edit text: <H1>" in the "dialog_variation_type_form" region
+    And I should not see the link "Edit selector" in the "dialog_variation_type_form" region
+    When I fill in "Test Article Title - Updated 2" for "personalize_elements_content"
+    And I click "#edit-variation-type-submit-form" element in the "dialog_variation_type_form" region
     And I wait for AJAX to finish
+
+    # I verify my new variation is add.
     Then I should see the message "The variation has been created." in the messagebox
     When I wait for AJAX to finish
     Then I should not see the variation type form dialog
-    And I should see the text "Test 2" in the "page_content" region
+    And I should see the text "Test Article Title - Updated 2" in the "page_content" region
     And I should see "1" for the "variation set" count
     When I hover over "Variation Sets" in the "lift_tray" region
+    Then I should see the link "Variation #1" in the "lift_tray" region
     Then I should see the link "Variation #2" in the "lift_tray" region
 
-  @api @javascript @campaign
   Scenario: Edit existing personalize elements for an acquia_lift campaign.
+    # I have a campaign and a variation set.
+    # I login with the marketer role.
+    # I am on an article page.
     Given "acquia_lift" agents:
-      | machine_name                    | label |
+      | machine_name                     | label                            |
       | testing-campaign-edit-variations | Testing campaign edit variations |
     And personalized elements:
-      | label                     | agent                            | selector     | type     | content                 |
-      | Page title updated         | testing-campaign-edit-variations | #page-title | editText | The Rainbow Connection  |
-    And I am logged in as a user with the "Marketer" role
+      | label              | agent                            | selector    | type     | content                |
+      | Page title updated | testing-campaign-edit-variations | #page-title | editText | The Rainbow Connection |
+    And I am logged in as a user with the "access administration pages,access toolbar,administer visitor actions,manage personalized content" permission
+    And I am on the homepage
     And I am viewing an "Article" content:
-      | title | My article title |
-      | body  | A placeholder           |
+      | title | Test Article Title - Original |
     When I click "Acquia Lift" in the "menu" region
     And I wait for AJAX to finish
     Then I should see the link "Campaigns" in the "lift_tray" region
+
+    # I open the variation set's menu.
     When I hover over "Campaigns" in the "lift_tray" region
     And I click "Testing campaign edit variations" in the "lift_tray" region
     And I wait for AJAX to finish
-    Then I should see the link "Variation Sets" visible in the "lift_tray" region
+    Then I should visibly see the link "Variation Sets" in the "lift_tray" region
     And I should see "1" for the "variation set" count
+
+    # I bring up the "Edit" variation set interface.
     When I hover over "Variation Sets" in the "lift_tray" region
-    Then I should see the text "Site name updated" in the "lift_tray" region
-    And I should see the link "Option A" visible in the "lift_tray" region
-    And "Site name updated" set "Control variation" variation should not have the "Edit" link
-    And "Site name updated" set "Control variation" variation should not have the "Delete" link
-    And "Site name updated" set "Option A" variation should have the "Edit" link
-    And "Site name updated" set "Option A" variation should have the "Delete" link
+    Then I should see the text "Page title updated" in the "lift_tray" region
+    And I should visibly see the link "Option A" in the "lift_tray" region
+    And "Page title updated" set "Control variation" variation should not have the "Edit" link
+    And "Page title updated" set "Control variation" variation should not have the "Delete" link
+    And "Page title updated" set "Option A" variation should have the "Edit" link
+    And "Page title updated" set "Option A" variation should have the "Delete" link
+
+    # I edit the variation set.
     When I click "Edit" link for the "Page title updated" set "Option A" variation
     And I wait for AJAX to finish
     Then I should see the text "Edit text: <H1>" in the "dialog_variation_type_form" region
@@ -103,8 +128,10 @@ Feature: Personalize elements variations can be edited for an existing campaign.
     And the "option_label" field should contain "Option A"
     When I fill in "Variation 1" for "option_label"
     And I fill in "Moving Right Along" for "personalize_elements_content"
-    And I press the "Save" button
+    And I click "#edit-variation-type-submit-form" element in the "dialog_variation_type_form" region
     And I wait for AJAX to finish
+
+    # I verify my variation is updated.
     Then I should see the message "The variation has been updated." in the messagebox
     When I wait for AJAX to finish
     Then I should not see the variation type form dialog
@@ -112,63 +139,81 @@ Feature: Personalize elements variations can be edited for an existing campaign.
     And I should see "1" for the "variation set" count
     When I hover over "Variation Sets" in the "lift_tray" region
     And I wait for AJAX to finish
-    Then I should see the text "Site name updated" in the "lift_tray" region
-    And I should see the link "Variation 1" visible in the "lift_tray" region
+    Then I should see the text "Page title updated" in the "lift_tray" region
+    And I should visibly see the link "Variation 1" in the "lift_tray" region
 
-  @api @javascript @campaign
   Scenario: Delete an existing personalize element variation for an acquia_lift campaign.
+    # I have a campaign and a variation set.
+    # I login with the marketer role.
+    # I am on an article page.
     Given "acquia_lift" agents:
-      | machine_name                    | label |
-      | testing-campaign-edit-variations | Testing campaign edit variations |
+      | machine_name                       | label                              |
+      | testing-campaign-delete-variations | Testing campaign delete variations |
     And personalized elements:
-      | label                     | agent                            | selector     | type     | content                 |
-      | Site name updated         | testing-campaign-edit-variations | #site-name a | editText | The Rainbow Connection, Moving Right Along  |
-    And I am logged in as a user with the "Marketer" role
+      | label              | agent                              | selector    | type     | content                                    |
+      | Page title updated | testing-campaign-delete-variations | #page-title | editText | The Rainbow Connection, Moving Right Along |
+    And I am logged in as a user with the "access administration pages,access toolbar,administer visitor actions,manage personalized content" permission
     And I am on the homepage
+    And I am viewing an "Article" content:
+      | title | Test Article Title - Original |
     When I click "Acquia Lift" in the "menu" region
     And I wait for AJAX to finish
     Then I should see the link "Campaigns" in the "lift_tray" region
+
+    # I open the variation set's menu.
     When I hover over "Campaigns" in the "lift_tray" region
-    And I click "Testing campaign edit variations" in the "lift_tray" region
+    And I click "Testing campaign delete variations" in the "lift_tray" region
     And I wait for AJAX to finish
-    Then I should see the link "Variation Sets" visible in the "lift_tray" region
+    Then I should visibly see the link "Variation Sets" in the "lift_tray" region
     And I should see "1" for the "variation set" count
+
+    # I bring up the "Delete" variation set interface.
     When I hover over "Variation Sets" in the "lift_tray" region
-    Then I should see the text "Site name updated" in the "lift_tray" region
-    And I should see the link "Option A" visible in the "lift_tray" region
-    And I should see the link "Option B" visible in the "lift_tray" region
-    And "Site name updated" set "Control variation" variation should not have the "Edit" link
-    And "Site name updated" set "Control variation" variation should not have the "Delete" link
-    And "Site name updated" set "Option A" variation should have the "Edit" link
-    And "Site name updated" set "Option A" variation should have the "Delete" link
-    And "Site name updated" set "Option B" variation should have the "Edit" link
-    And "Site name updated" set "Option B" variation should have the "Delete" link
-    When I click "Delete" link for the "Site name updated" set "Option A" variation
+    Then I should see the text "Page title updated" in the "lift_tray" region
+    And I should visibly see the link "Option A" in the "lift_tray" region
+    And I should visibly see the link "Option B" in the "lift_tray" region
+    And "Page title updated" set "Control variation" variation should not have the "Edit" link
+    And "Page title updated" set "Control variation" variation should not have the "Delete" link
+    And "Page title updated" set "Option A" variation should have the "Edit" link
+    And "Page title updated" set "Option A" variation should have the "Delete" link
+    And "Page title updated" set "Option B" variation should have the "Edit" link
+    And "Page title updated" set "Option B" variation should have the "Delete" link
+
+    # I delete a variation, "Option A".
+    When I click "Delete" link for the "Page title updated" set "Option A" variation
     And I wait for AJAX to finish
     Then I should see the modal with title "Delete variation"
     When I press "Delete"
     And I wait for AJAX to finish
-    Then I should see the message "The variation has been deleted" in the messagebox
+
+    # I verify the variation "Option A" is deleted.
+    Then I should see the message "The variation has been deleted." in the messagebox
     When I wait for AJAX to finish
     Then I should see "1" for the "variation set" count
     When I hover over "Variation Sets" in the "lift_tray" region
-    Then I should see the text "Site name updated" in the "lift_tray" region
-    And I should not see the link "Option A" visible in the "lift_tray" region
-    And I should see the link "Option B" visible in the "lift_tray" region
-    And "Site name updated" set "Control variation" variation should not have the "Edit" link
-    And "Site name updated" set "Control variation" variation should not have the "Delete" link
-    And "Site name updated" set "Option B" variation should have the "Edit" link
-    And "Site name updated" set "Option B" variation should have the "Delete" link
-    When I click "Delete" link for the "Site name updated" set "Option B" variation
+    Then I should see the text "Page title updated" in the "lift_tray" region
+    And I should not see the link "Option A" in the "lift_tray" region
+    And I should visibly see the link "Option B" in the "lift_tray" region
+    And "Page title updated" set "Control variation" variation should not have the "Edit" link
+    And "Page title updated" set "Control variation" variation should not have the "Delete" link
+    And "Page title updated" set "Option B" variation should have the "Edit" link
+    And "Page title updated" set "Option B" variation should have the "Delete" link
+
+    # I delete another variation, "Option B".
+    When I click "Delete" link for the "Page title updated" set "Option B" variation
     And I wait for AJAX to finish
     Then I should see the modal with title "Delete variation"
     When I press "Delete"
     And I wait for AJAX to finish
-    Then I should see the message "The variation set has been deleted" in the messagebox
+
+    # I verify the variation "Option B" is deleted.
+    Then I should see the message "The variation set has been deleted." in the messagebox
     When I wait for AJAX to finish
     Then I should see "0" for the "variation set" count
     When I hover over "Variation Sets" in the "lift_tray" region
-    Then I should not see the text "Site name updated" in the "lift_tray" region
-    And I should not see the link "Option B" visible in the "lift_tray" region
-    And I should not see the link "Control variation" visible in the "lift_tray" region
+    Then I should not see the text "Page title updated" in the "lift_tray" region
+    And I should not see the link "Option B" in the "lift_tray" region
+
+    # I verify both variations are deleted and there is none left.
+    And I should not see the link "Control variation" in the "lift_tray" region
     And I should see the text "No variations" in the "lift_tray" region

--- a/behat-tests/features/acquia_lift_element_variations.feature
+++ b/behat-tests/features/acquia_lift_element_variations.feature
@@ -22,7 +22,6 @@ Feature: Personalize elements variations can be edited for an existing campaign.
     # I open the variation set's menu.
     When I hover over "Campaigns" in the "lift_tray" region
     And I click "Testing campaign add variations" in the "lift_tray" region
-    And I wait for AJAX to finish
     Then I should visibly see the link "Variation Sets" in the "lift_tray" region
     And I should see "0" for the "variation set" count
 
@@ -31,30 +30,24 @@ Feature: Personalize elements variations can be edited for an existing campaign.
     Then I should see the link "Add variation set" in the "lift_tray" region
     Then I should see the link "All variation sets" in the "lift_tray" region
     When I click "Add variation set"
-    And I wait for AJAX to finish
     Then I should see the modal with title "Add a variation set"
     And I should see the link "Webpage elements" in the "modal_content" region
     And I should see the link "Drupal blocks" in the "modal_content" region
     When I click "Webpage elements" in the "modal_content" region
-    And I wait for AJAX to finish
     Then I should not see the modal
 
     # I add a new variation set.
     When I click "#page-title" element in the "page_content" region
-    And I wait for AJAX to finish
     Then I should see the text "<H1>" in the "dialog_variation_type" region
     When I click "Edit text" in the "dialog_variation_type" region
-    And I wait for AJAX to finish
     Then I should not see the variation type dialog
     And I should see the text "Edit text: <H1>" in the "dialog_variation_type_form" region
     When I fill in "Test Article Title - Updated 1" for "personalize_elements_content"
     And I fill in "Test variation set" for "title"
     And I click "#edit-variation-type-submit-form" element in the "dialog_variation_type_form" region
-    And I wait for AJAX to finish
 
     # I verify my variation set is created.
     Then I should see the message "The variation set has been created." in the messagebox
-    When I wait for AJAX to finish
     Then I should not see the variation type form dialog
     And I should see the text "Test Article Title" in the "page_content" region
     And I should see "1" for the "variation set" count
@@ -74,11 +67,9 @@ Feature: Personalize elements variations can be edited for an existing campaign.
     And I should not see the link "Edit selector" in the "dialog_variation_type_form" region
     When I fill in "Test Article Title - Updated 2" for "personalize_elements_content"
     And I click "#edit-variation-type-submit-form" element in the "dialog_variation_type_form" region
-    And I wait for AJAX to finish
 
     # I verify my new variation is add.
     Then I should see the message "The variation has been created." in the messagebox
-    When I wait for AJAX to finish
     Then I should not see the variation type form dialog
     And I should see the text "Test Article Title - Updated 2" in the "page_content" region
     And I should see "1" for the "variation set" count
@@ -107,7 +98,6 @@ Feature: Personalize elements variations can be edited for an existing campaign.
     # I open the variation set's menu.
     When I hover over "Campaigns" in the "lift_tray" region
     And I click "Testing campaign edit variations" in the "lift_tray" region
-    And I wait for AJAX to finish
     Then I should visibly see the link "Variation Sets" in the "lift_tray" region
     And I should see "1" for the "variation set" count
 
@@ -122,23 +112,19 @@ Feature: Personalize elements variations can be edited for an existing campaign.
 
     # I edit the variation set.
     When I click "Edit" link for the "Page title updated" set "Option A" variation
-    And I wait for AJAX to finish
     Then I should see the text "Edit text: <H1>" in the "dialog_variation_type_form" region
     And the "personalize_elements_content" field should contain "The Rainbow Connection"
     And the "option_label" field should contain "Option A"
     When I fill in "Variation 1" for "option_label"
     And I fill in "Moving Right Along" for "personalize_elements_content"
     And I click "#edit-variation-type-submit-form" element in the "dialog_variation_type_form" region
-    And I wait for AJAX to finish
 
     # I verify my variation is updated.
     Then I should see the message "The variation has been updated." in the messagebox
-    When I wait for AJAX to finish
     Then I should not see the variation type form dialog
     And I should see the text "Moving Right Along" in the "page_content" region
     And I should see "1" for the "variation set" count
     When I hover over "Variation Sets" in the "lift_tray" region
-    And I wait for AJAX to finish
     Then I should see the text "Page title updated" in the "lift_tray" region
     And I should visibly see the link "Variation 1" in the "lift_tray" region
 
@@ -163,7 +149,6 @@ Feature: Personalize elements variations can be edited for an existing campaign.
     # I open the variation set's menu.
     When I hover over "Campaigns" in the "lift_tray" region
     And I click "Testing campaign delete variations" in the "lift_tray" region
-    And I wait for AJAX to finish
     Then I should visibly see the link "Variation Sets" in the "lift_tray" region
     And I should see "1" for the "variation set" count
 
@@ -181,14 +166,11 @@ Feature: Personalize elements variations can be edited for an existing campaign.
 
     # I delete a variation, "Option A".
     When I click "Delete" link for the "Page title updated" set "Option A" variation
-    And I wait for AJAX to finish
     Then I should see the modal with title "Delete variation"
     When I press "Delete"
-    And I wait for AJAX to finish
 
     # I verify the variation "Option A" is deleted.
     Then I should see the message "The variation has been deleted." in the messagebox
-    When I wait for AJAX to finish
     Then I should see "1" for the "variation set" count
     When I hover over "Variation Sets" in the "lift_tray" region
     Then I should see the text "Page title updated" in the "lift_tray" region
@@ -201,14 +183,11 @@ Feature: Personalize elements variations can be edited for an existing campaign.
 
     # I delete another variation, "Option B".
     When I click "Delete" link for the "Page title updated" set "Option B" variation
-    And I wait for AJAX to finish
     Then I should see the modal with title "Delete variation"
     When I press "Delete"
-    And I wait for AJAX to finish
 
     # I verify the variation "Option B" is deleted.
     Then I should see the message "The variation set has been deleted." in the messagebox
-    When I wait for AJAX to finish
     Then I should see "0" for the "variation set" count
     When I hover over "Variation Sets" in the "lift_tray" region
     Then I should not see the text "Page title updated" in the "lift_tray" region

--- a/behat-tests/features/acquia_lift_element_variations.feature
+++ b/behat-tests/features/acquia_lift_element_variations.feature
@@ -12,7 +12,6 @@ Feature: Personalize elements variations can be edited for an existing campaign.
       | machine_name                    | label                           |
       | testing-campaign-add-variations | Testing campaign add variations |
     And I am logged in as a user with the "access administration pages,access toolbar,administer visitor actions,manage personalized content" permission
-    And I am on the homepage
     And I am viewing an "Article" content:
       | title | Test Article Title - Original |
     When I click "Acquia Lift" in the "menu" region
@@ -62,7 +61,7 @@ Feature: Personalize elements variations can be edited for an existing campaign.
 
     # I add a new variation to to the existing variation set.
     When I click "Add variation" in the "lift_tray" region
-    Then "#page-title" element in the "page_content" region should have "acquia-lift-page-variation-item" class
+    Then I should see "#page-title" element in the "page_content" region is "highlighted" for editing
     And I should see the text "Edit text: <H1>" in the "dialog_variation_type_form" region
     And I should not see the link "Edit selector" in the "dialog_variation_type_form" region
     When I fill in "Test Article Title - Updated 2" for "personalize_elements_content"
@@ -88,7 +87,6 @@ Feature: Personalize elements variations can be edited for an existing campaign.
       | label              | agent                            | selector    | type     | content                |
       | Page title updated | testing-campaign-edit-variations | #page-title | editText | The Rainbow Connection |
     And I am logged in as a user with the "access administration pages,access toolbar,administer visitor actions,manage personalized content" permission
-    And I am on the homepage
     And I am viewing an "Article" content:
       | title | Test Article Title - Original |
     When I click "Acquia Lift" in the "menu" region
@@ -139,7 +137,6 @@ Feature: Personalize elements variations can be edited for an existing campaign.
       | label              | agent                              | selector    | type     | content                                    |
       | Page title updated | testing-campaign-delete-variations | #page-title | editText | The Rainbow Connection, Moving Right Along |
     And I am logged in as a user with the "access administration pages,access toolbar,administer visitor actions,manage personalized content" permission
-    And I am on the homepage
     And I am viewing an "Article" content:
       | title | Test Article Title - Original |
     When I click "Acquia Lift" in the "menu" region

--- a/behat-tests/features/acquia_lift_element_variations.feature
+++ b/behat-tests/features/acquia_lift_element_variations.feature
@@ -41,8 +41,10 @@ Feature: Personalize elements variations can be edited for an existing campaign.
     When I click "Edit text" in the "dialog_variation_type" region
     Then I should not see the variation type dialog
     And I should see the text "Edit text: <H1>" in the "dialog_variation_type_form" region
+    And the "personalize_elements_content" field should contain text that has "Test Article Title - Original"
     When I fill in "Test Article Title - Updated 1" for "personalize_elements_content"
     And I fill in "Test variation set" for "title"
+    # There are two "Save" buttons on the page and we are clicking one by element id.
     And I click "#edit-variation-type-submit-form" element in the "dialog_variation_type_form" region
 
     # I verify my variation set is created.
@@ -66,6 +68,7 @@ Feature: Personalize elements variations can be edited for an existing campaign.
     And the "personalize_elements_content" field should contain "Test Article Title - Updated 1"
     And I should not see the link "Edit selector" in the "dialog_variation_type_form" region
     When I fill in "Test Article Title - Updated 2" for "personalize_elements_content"
+    # There are two "Save" buttons on the page and we are clicking one by element id.
     And I click "#edit-variation-type-submit-form" element in the "dialog_variation_type_form" region
 
     # I verify my new variation is add.
@@ -116,6 +119,7 @@ Feature: Personalize elements variations can be edited for an existing campaign.
     And the "option_label" field should contain "Option A"
     When I fill in "Variation 1" for "option_label"
     And I fill in "Moving Right Along" for "personalize_elements_content"
+    # There are two "Save" buttons on the page and we are clicking one by element id.
     And I click "#edit-variation-type-submit-form" element in the "dialog_variation_type_form" region
 
     # I verify my variation is updated.

--- a/behat-tests/features/acquia_lift_element_variations.feature
+++ b/behat-tests/features/acquia_lift_element_variations.feature
@@ -10,7 +10,9 @@ Feature: Personalize elements variations can be edited for an existing campaign.
       | machine_name                    | label |
       | testing-campaign-add-variations | Testing campaign add variations |
     And I am logged in as a user with the "Marketer" role
-    And I am on the homepage
+    And I am viewing an "Article" content:
+      | title | My article title |
+      | body  | A placeholder           |
     When I click "Acquia Lift" in the "menu" region
     And I wait for AJAX to finish
     Then I should see the link "Campaigns" in the "lift_tray" region
@@ -29,14 +31,14 @@ Feature: Personalize elements variations can be edited for an existing campaign.
     When I click "Webpage elements" in the "modal_content" region
     And I wait for AJAX to finish
     Then I should not see the modal
-    When I click "#site-name a span" element in the "page_content" region
+    When I click "#page-title" element in the "page_content" region
     And I wait for AJAX to finish
-    Then I should see the text "<SPAN>" in the "dialog_variation_type" region
+    Then I should see the text "<H1>" in the "dialog_variation_type" region
     When I click "Edit text" in the "dialog_variation_type" region
     And I wait for AJAX to finish
     Then I should not see the variation type dialog
-    And I should see the text "Edit text: <SPAN>" in the "dialog_variation_type_form" region
-    And the "personalize_elements_content" field should contain the site title
+    And I should see the text "Edit text: <H1>" in the "dialog_variation_type_form" region
+    And the "personalize_elements_content" field should contain "My article title"
     When I fill in "Test 1" for "personalize_elements_content"
     And I fill in "Test variation set" for "title"
     And I press the "Save" button
@@ -53,8 +55,8 @@ Feature: Personalize elements variations can be edited for an existing campaign.
     And I should see the link "Add variation" in the "lift_tray" region
     And I should see the link "Add variation set" in the "lift_tray" region
     When I click "Add variation" in the "lift_tray" region
-    Then "#site-name a span" element in the "page_content" region should have "acquia-lift-page-variation-item" class
-    And I should see the text "Edit text: <SPAN>" in the "dialog_variation_type_form" region
+    Then "#page-title" element in the "page_content" region should have "acquia-lift-page-variation-item" class
+    And I should see the text "Edit HTML: <H1>" in the "dialog_variation_type_form" region
     And I should not see the link "Edit selector" visible in the "dialog_variation_type_form" region
     When I fill in "Test 2" for "personalize_elements_content"
     And I press the "Save" button
@@ -74,9 +76,11 @@ Feature: Personalize elements variations can be edited for an existing campaign.
       | testing-campaign-edit-variations | Testing campaign edit variations |
     And personalized elements:
       | label                     | agent                            | selector     | type     | content                 |
-      | Site name updated         | testing-campaign-edit-variations | #site-name a | editText | The Rainbow Connection  |
+      | Page title updated         | testing-campaign-edit-variations | #page-title | editText | The Rainbow Connection  |
     And I am logged in as a user with the "Marketer" role
-    And I am on the homepage
+    And I am viewing an "Article" content:
+      | title | My article title |
+      | body  | A placeholder           |
     When I click "Acquia Lift" in the "menu" region
     And I wait for AJAX to finish
     Then I should see the link "Campaigns" in the "lift_tray" region
@@ -92,9 +96,9 @@ Feature: Personalize elements variations can be edited for an existing campaign.
     And "Site name updated" set "Control variation" variation should not have the "Delete" link
     And "Site name updated" set "Option A" variation should have the "Edit" link
     And "Site name updated" set "Option A" variation should have the "Delete" link
-    When I click "Edit" link for the "Site name updated" set "Option A" variation
+    When I click "Edit" link for the "Page title updated" set "Option A" variation
     And I wait for AJAX to finish
-    Then I should see the text "Edit text: <A>" in the "dialog_variation_type_form" region
+    Then I should see the text "Edit text: <H1>" in the "dialog_variation_type_form" region
     And the "personalize_elements_content" field should contain "The Rainbow Connection"
     And the "option_label" field should contain "Option A"
     When I fill in "Variation 1" for "option_label"

--- a/behat-tests/features/acquia_lift_goals.feature
+++ b/behat-tests/features/acquia_lift_goals.feature
@@ -1,30 +1,37 @@
-#Assumes Marketer role.
+@api @javascript @insulated @campaign
 Feature: Goals can be edited and managed for an Acquia Lift campaign from toolbar.
   In order to manage goals in context
   As a site marketer
   I want the ability to add, edit, and delete existing goals from the Lift toolbar.
 
-  @api @javascript @campaign
   Scenario: Add page level goals to a campaign
+    # I have a campaign.
+    # I login with the marketer role.
     Given "acquia_lift" agents:
-      | machine_name                    | label |
+      | machine_name                    | label                          |
       | testing-campaign-add-goals-page | Testing campaign add page goal |
-    And I am logged in as a user with the "Marketer" role
+    And I am logged in as a user with the "access administration pages,access toolbar,administer visitor actions,manage personalized content" permission
     And I am on the homepage
     When I click "Acquia Lift" in the "menu" region
     And I wait for AJAX to finish
     Then I should see the link "Campaigns" in the "lift_tray" region
+
+    # I open the goal's menu.
     When I hover over "Campaigns" in the "lift_tray" region
     And I click "Testing campaign add page goal" in the "lift_tray" region
     And I wait for AJAX to finish
-    Then I should see the link "Goals" visible in the "lift_tray" region
+    Then I should visibly see the link "Goals" in the "lift_tray" region
     And I should see "0" for the "goal" count
+
+    # I bring up the "Add goal" interface.
     When I hover over "Goals" in the "lift_tray" region
-    And I should see the link "Add goal" visible in the "lift_tray" region
+    And I should visibly see the link "Add goal" in the "lift_tray" region
     When I click "Add goal" in the "lift_tray" region
     And I wait for AJAX to finish
     Then I should see the modal with title "Add a goal"
     And I should see the link "New page goal" in the "modal_content" region
+
+    # I add a new page goal.
     When I click "New page goal" in the "modal_content" region
     And I wait for AJAX to finish
     When I select "scrolls to the bottom of" from "Event"
@@ -39,6 +46,8 @@ Feature: Goals can be edited and managed for an Acquia Lift campaign from toolba
     When I fill in "Test goal #1" for "Title"
     And I press "Add goal"
     And I wait for AJAX to finish
+
+    # I verify my page goal is added.
     Then I should see the message "Test goal #1 goal added to campaign" in the messagebox
     And I should not see the modal
     When I wait for AJAX to finish
@@ -46,31 +55,40 @@ Feature: Goals can be edited and managed for an Acquia Lift campaign from toolba
     When I hover over "Goals" in the "lift_tray" region
     Then I should see the text "Test goal #1" in the "lift_tray" region
 
-  @api @javascript @campaign
   Scenario: Add pre-existing goals to a campaign
+    # I have a campaign.
+    # I login with the marketer role.
     Given "acquia_lift" agents:
-      | machine_name                    | label |
+      | machine_name                       | label                              |
       | testing-campaign-add-existing-goal | Testing campaign add existing goal |
-    And I am logged in as a user with the "Marketer" role
+    And I am logged in as a user with the "access administration pages,access toolbar,administer visitor actions,manage personalized content" permission
     And I am on the homepage
     When I click "Acquia Lift" in the "menu" region
     And I wait for AJAX to finish
     Then I should see the link "Campaigns" in the "lift_tray" region
+
+    # I open the goal's menu.
     When I hover over "Campaigns" in the "lift_tray" region
     And I click "Testing campaign add existing goal" in the "lift_tray" region
-    Then I should see the link "Goals" visible in the "lift_tray" region
+    Then I should visibly see the link "Goals" in the "lift_tray" region
     And I should see "0" for the "goal" count
+
+    # I bring up the "Add goal" interface, again.
     When I hover over "Goals" in the "lift_tray" region
-    And I should see the link "Add goal" visible in the "lift_tray" region
+    And I should visibly see the link "Add goal" in the "lift_tray" region
     When I click "Add goal" in the "lift_tray" region
     And I wait for AJAX to finish
     Then I should see the modal with title "Add a goal"
     And I should see the link "Predefined goal" in the "modal_content" region
+
+    # I register a predefined goal to this campaign.
     When I click "Predefined goal" in the "modal_content" region
     And I wait for AJAX to finish
     When I select "Registers" from "Goal"
     And I press "Add goal"
     And I wait for AJAX to finish
+
+    # I verify my predefined goal is registered with this campaign.
     Then I should see the message "Registers goal added to campaign" in the messagebox
     And I should not see the modal
     When I wait for AJAX to finish
@@ -78,26 +96,34 @@ Feature: Goals can be edited and managed for an Acquia Lift campaign from toolba
     When I hover over "Goals" in the "lift_tray" region
     Then I should see the text "Registers" in the "lift_tray" region
 
-  @api @javascript @campaign
   Scenario: Add an element goals to a campaign
+    # I have a campaign.
+    # I login with the marketer role.
     Given "acquia_lift" agents:
-      | machine_name                    | label |
+      | machine_name                      | label                             |
       | testing-campaign-add-element-goal | Testing campaign add element goal |
-    And I am logged in as a user with the "Marketer" role
+    And I am logged in as a user with the "access administration pages,access toolbar,administer visitor actions,manage personalized content" permission
     And I am on the homepage
     When I click "Acquia Lift" in the "menu" region
     And I wait for AJAX to finish
     Then I should see the link "Campaigns" in the "lift_tray" region
+
+    # I open and see the goal's menu.
     When I hover over "Campaigns" in the "lift_tray" region
     And I click "Testing campaign add element goal" in the "lift_tray" region
-    Then I should see the link "Goals" visible in the "lift_tray" region
+    Then I should visibly see the link "Goals" in the "lift_tray" region
     And I should see "0" for the "goal" count
+
+    # I bring up the "Add goal" interface.
     When I hover over "Goals" in the "lift_tray" region
-    And I should see the link "Add goal" visible in the "lift_tray" region
+    And I should visibly see the link "Add goal" in the "lift_tray" region
     When I click "Add goal" in the "lift_tray" region
     And I wait for AJAX to finish
     Then I should see the modal with title "Add a goal"
     And I should see the link "New element goal" in the "modal_content" region
+
+    # I appoint the "logo" element as the goal element,
+    # and specify "hovers over" option to be the goal.
     When I click "New element goal" in the "modal_content" region
     And I wait for AJAX to finish
     Then I should not see the modal
@@ -110,6 +136,9 @@ Feature: Goals can be edited and managed for an Acquia Lift campaign from toolba
     When I fill in "New goal #2" for "Title"
     And I select "hovers over" from "Event"
     And I press "Save" in the "dialog_goal_form" region
+    And I wait for AJAX to finish
+
+    # I verify my new element goal is added.
     Then I should see the message "The action New goal #2 was saved."
     Then I should see "1" for the "goal" count
     When I hover over "Goals" in the "lift_tray" region

--- a/behat-tests/features/acquia_lift_goals.feature
+++ b/behat-tests/features/acquia_lift_goals.feature
@@ -19,7 +19,6 @@ Feature: Goals can be edited and managed for an Acquia Lift campaign from toolba
     # I open the goal's menu.
     When I hover over "Campaigns" in the "lift_tray" region
     And I click "Testing campaign add page goal" in the "lift_tray" region
-    And I wait for AJAX to finish
     Then I should visibly see the link "Goals" in the "lift_tray" region
     And I should see "0" for the "goal" count
 
@@ -27,7 +26,6 @@ Feature: Goals can be edited and managed for an Acquia Lift campaign from toolba
     When I hover over "Goals" in the "lift_tray" region
     And I should visibly see the link "Add goal" in the "lift_tray" region
     When I click "Add goal" in the "lift_tray" region
-    And I wait for AJAX to finish
     Then I should see the modal with title "Add a goal"
     And I should see the link "New page goal" in the "modal_content" region
 
@@ -45,12 +43,10 @@ Feature: Goals can be edited and managed for an Acquia Lift campaign from toolba
     And I should not see the text "Offset from bottom" in the "modal_content" region
     When I fill in "Test goal #1" for "Title"
     And I press "Add goal"
-    And I wait for AJAX to finish
 
     # I verify my page goal is added.
     Then I should see the message "Test goal #1 goal added to campaign" in the messagebox
     And I should not see the modal
-    When I wait for AJAX to finish
     Then I should see "1" for the "goal" count
     When I hover over "Goals" in the "lift_tray" region
     Then I should see the text "Test goal #1" in the "lift_tray" region
@@ -77,7 +73,6 @@ Feature: Goals can be edited and managed for an Acquia Lift campaign from toolba
     When I hover over "Goals" in the "lift_tray" region
     And I should visibly see the link "Add goal" in the "lift_tray" region
     When I click "Add goal" in the "lift_tray" region
-    And I wait for AJAX to finish
     Then I should see the modal with title "Add a goal"
     And I should see the link "Predefined goal" in the "modal_content" region
 
@@ -86,12 +81,10 @@ Feature: Goals can be edited and managed for an Acquia Lift campaign from toolba
     And I wait for AJAX to finish
     When I select "Registers" from "Goal"
     And I press "Add goal"
-    And I wait for AJAX to finish
 
     # I verify my predefined goal is registered with this campaign.
     Then I should see the message "Registers goal added to campaign" in the messagebox
     And I should not see the modal
-    When I wait for AJAX to finish
     Then I should see "1" for the "goal" count
     When I hover over "Goals" in the "lift_tray" region
     Then I should see the text "Registers" in the "lift_tray" region
@@ -118,14 +111,12 @@ Feature: Goals can be edited and managed for an Acquia Lift campaign from toolba
     When I hover over "Goals" in the "lift_tray" region
     And I should visibly see the link "Add goal" in the "lift_tray" region
     When I click "Add goal" in the "lift_tray" region
-    And I wait for AJAX to finish
     Then I should see the modal with title "Add a goal"
     And I should see the link "New element goal" in the "modal_content" region
 
     # I appoint the "logo" element as the goal element,
     # and specify "hovers over" option to be the goal.
     When I click "New element goal" in the "modal_content" region
-    And I wait for AJAX to finish
     Then I should not see the modal
     And "#logo" element in the "page_content" region should have "visitor-actions-ui-enabled" class
     When I click "logo" in the "page_content" region

--- a/behat-tests/features/acquia_lift_goals.feature
+++ b/behat-tests/features/acquia_lift_goals.feature
@@ -118,7 +118,7 @@ Feature: Goals can be edited and managed for an Acquia Lift campaign from toolba
     # and specify "hovers over" option to be the goal.
     When I click "New element goal" in the "modal_content" region
     Then I should not see the modal
-    And "#logo" element in the "page_content" region should have "visitor-actions-ui-enabled" class
+    Then I should see "#logo" element in the "page_content" region is "available" for editing
     When I click "logo" in the "page_content" region
     And I wait for AJAX to finish
     Then I should see "Title" in the "dialog_goal_form" region

--- a/behat-tests/features/acquia_lift_simple_ab.feature
+++ b/behat-tests/features/acquia_lift_simple_ab.feature
@@ -9,7 +9,6 @@ Feature: Creation of Simple A/B campaigns from unified navigation.
     Given I am logged in as a user with the "access administration pages,access toolbar,administer visitor actions,manage personalized content" permission
     And I am on the homepage
     When I click "Acquia Lift" in the "menu" region
-    And I wait for AJAX to finish
     Then I should visibly see the link "Campaigns" in the "lift_tray" region
     And I should not visibly see the link "Variation sets" in the "lift_tray" region
     And I should not visibly see the link "Goals" in the "lift_tray" region
@@ -18,36 +17,29 @@ Feature: Creation of Simple A/B campaigns from unified navigation.
 
     # I bring up the "Create a campaign" interface.
     When I hover over "Campaigns" in the "lift_tray" region
-    And I wait for AJAX to finish
     Then I should see the link "Add campaign" in the "lift_tray" region
     Then I should see the link "All campaigns" in the "lift_tray" region
     When I click "Add campaign" in the "lift_tray" region
-    And I wait for AJAX to finish
     Then I should see the modal with title "Create a campaign"
     And I should see the link "A/B test" in the "modal_content" region
     And I should see the link "Custom Lift campaign" in the "modal_content" region
 
     # I create a simple A/B test campaign.
     When I click "A/B test" in the "modal_content" region
-    And I wait for AJAX to finish
     Then I should see the modal with title "Create a campaign"
     And I should see the link "Change type of test" in the "modal_content" region
     When I click "Change type of test" in the "modal_content" region
-    And I wait for AJAX to finish
     Then I should see the modal with title "Create a campaign"
     And I should see the link "A/B test" in the "modal_content" region
     And I should see the link "Custom Lift campaign" in the "modal_content" region
     When I click "A/B test" in the "modal_content" region
-    And I wait for AJAX to finish
     Then I should see the modal with title "Create a campaign"
     And I should see the link "Change type of test" in the "modal_content" region
     When I fill in "My test campaign" for "edit-agent-basic-info-title"
     And I press the "Create campaign" button
-    And I wait for AJAX to finish
 
     # I verify my campaign is created.
     Then I should see the message "Click the element you want to change in Variation #1" in the messagebox
-    Then I wait for AJAX to finish
     When I should see the text "Campaign: My test campaign" in the "lift_tray_campaign_header" region
     And I should visibly see the link "Variations" in the "lift_tray" region
     And I should see "0" for the "variation" count
@@ -60,7 +52,6 @@ Feature: Creation of Simple A/B campaigns from unified navigation.
 
     # I create a new variation.
     When I click "#site-name a span" element in the "page_content" region
-    And I wait for AJAX to finish
     Then I should see the text "<SPAN>" in the "dialog_variation_type" region
     When I click "Edit text" in the "dialog_variation_type" region
     And I wait for AJAX to finish
@@ -69,11 +60,9 @@ Feature: Creation of Simple A/B campaigns from unified navigation.
     And the "personalize_elements_content" field should contain the site title
     When I fill in "Lift Testing" for "personalize_elements_content"
     And I press the "Save" button
-    And I wait for AJAX to finish
 
     # I verify my variation is created.
     Then I should see the message "The variation has been created. Add one or more goals by clicking Goals > Add goal." in the messagebox
-    When I wait for AJAX to finish
     Then I should not see the variation type form dialog
     And I should see the text "Lift Testing"
     And the variation edit mode is "inactive"
@@ -83,7 +72,6 @@ Feature: Creation of Simple A/B campaigns from unified navigation.
     Then I should see the link "Add goal" in the "lift_tray" region
     Then I should see the link "All goals" in the "lift_tray" region
     When I click "Add goal" in the "lift_tray" region
-    And I wait for AJAX to finish
     Then I should see the modal with title "Add a goal"
     And I should see the link "Predefined goal" in the "modal_content" region
     And I should see the link "New element goal" in the "modal_content" region
@@ -91,11 +79,9 @@ Feature: Creation of Simple A/B campaigns from unified navigation.
 
     # I go to "Predefined goal" sub-menu then return.
     When I click "Predefined goal" in the "modal_content" region
-    And I wait for AJAX to finish
     Then I should see the modal with title "Add a goal"
     And I should see the link "Change type of goal" in the "modal_content" region
     When I click "Change type of goal" in the "modal_content" region
-    And I wait for AJAX to finish
 
     # I verify I am back to the "Add goal" interface.
     Then I should see the modal with title "Add a goal"
@@ -105,16 +91,13 @@ Feature: Creation of Simple A/B campaigns from unified navigation.
 
     # I add a new page goal.
     When I click "New page goal" in the "modal_content" region
-    And I wait for AJAX to finish
     Then I should see the modal with title "Add a goal"
     And I should see the link "Change type of goal" in the "modal_content" region
     When I fill in "My test goal" for "edit-title"
     And I press "Add goal"
-    And I wait for AJAX to finish
 
     # I verify my page goal is added.
     Then I should see the message "My test goal goal added to campaign." in the messagebox
-    When I wait for AJAX to finish
     Then I should see "1" for the "goal" count
     When I hover over "Goals" in the "lift_tray" region
     Then I should see the text "My test goal" in the "lift_tray" region
@@ -137,16 +120,13 @@ Feature: Creation of Simple A/B campaigns from unified navigation.
     And I wait for AJAX to finish
     Then I should see the link "Add campaign" in the "lift_tray" region
     When I click "Add campaign" in the "lift_tray" region
-    And I wait for AJAX to finish
     Then I should see the modal with title "Create a campaign"
 
     # I create my first simple A/B test campaign.
     When I click "A/B test" in the "modal_content" region
-    And I wait for AJAX to finish
     Then I should see the modal with title "Create a campaign"
     When I fill in "Test campaign 2" for "agent_basic_info[title]"
     And I press the "Create campaign" button
-    And I wait for AJAX to finish
 
     # I verify my first campaign is created.
     Then I should see the message "Click the element you want to change in Variation #1" in the messagebox
@@ -159,20 +139,16 @@ Feature: Creation of Simple A/B campaigns from unified navigation.
     And I wait for AJAX to finish
     Then I should see the link "Add campaign" in the "lift_tray" region
     When I click "Add campaign" in the "lift_tray" region
-    And I wait for AJAX to finish
     Then I should see the modal with title "Create a campaign"
     And the variation edit mode is "disabled"
 
     # I create my second simple A/B test campaign.
     When I click "A/B test" in the "modal_content" region
-    And I wait for AJAX to finish
     Then I should see the modal with title "Create a campaign"
     When I fill in "Test campaign 3" for "agent_basic_info[title]"
     And I press the "Create campaign" button
-    And I wait for AJAX to finish
 
     # I verify my second campaign is created.
     Then I should see the message "Click the element you want to change in Variation #1" in the messagebox
-    When I wait for AJAX to finish
     Then I should see the text "Campaign: Test campaign 3" in the "lift_tray_campaign_header" region
     And the variation edit mode is "active"

--- a/behat-tests/features/acquia_lift_simple_ab.feature
+++ b/behat-tests/features/acquia_lift_simple_ab.feature
@@ -1,132 +1,160 @@
-# Assumes roles: Marketer
-
+@api @javascript @insulated @campaign
 Feature: Creation of Simple A/B campaigns from unified navigation.
   In order to quickly create A/B tests
   As a site marketer
   I want the ability to create a campaign in context.
 
-@api @javascript @campaign
-Scenario: Create the simplest A/B campaign from start to finish.
-  Given I am logged in as a user with the "Marketer" role
-  And I am on the homepage
-  When I click "Acquia Lift" in the "menu" region
-  And I wait for AJAX to finish
-  Then I should see the link "Campaigns" in the "lift_tray" region
-  And I should not see the link "Variations" visible in the "lift_tray" region
-  And I should not see the link "Variation sets" visible in the "lift_tray" region
-  And I should not see the link "Goals" visible in the "lift_tray" region
-  And I should not see the link "Reports" visible in the "lift_tray" region
-  And I should not see the link "Status" visible in the "lift_tray" region
-  When I hover over "Campaigns" in the "lift_tray" region
-  And I wait for AJAX to finish
-  Then I should see the link "Add campaign" in the "lift_tray" region
-  Then I should see the link "All campaigns" in the "lift_tray" region
-  When I click "Add campaign" in the "lift_tray" region
-  And I wait for AJAX to finish
-  Then I should see the modal with title "Create a campaign"
-  And I should see the link "A/B test" in the "modal_content" region
-  And I should see the link "Custom Lift campaign" in the "modal_content" region
-  When I click "A/B test" in the "modal_content" region
-  And I wait for AJAX to finish
-  Then I should see the modal with title "Create a campaign"
-  And I should see the link "Change type of test" in the "modal_content" region
-  When I click "Change type of test" in the "modal_content" region
-  And I wait for AJAX to finish
-  Then I should see the modal with title "Create a campaign"
-  And I should see the link "A/B test" in the "modal_content" region
-  And I should see the link "Custom Lift campaign" in the "modal_content" region
-  When I click "A/B test" in the "modal_content" region
-  And I wait for AJAX to finish
-  Then I should see the modal with title "Create a campaign"
-  And I should see the link "Change type of test" in the "modal_content" region
-  When I fill in "My test campaign" for "edit-agent-basic-info-title"
-  And I press the "Create campaign" button
-  And I wait for AJAX to finish
-  Then I should see the message "Click the element you want to change in Variation #1" in the messagebox
-  When I wait for AJAX to finish
-  Then I should see the text "Campaign: My test campaign" in the "lift_tray_campaign_header" region
-  And I should see "0" for the "variation" count
-  And I should see the link "Variations" visible in the "lift_tray" region
-  And I should see the link "Goals" visible in the "lift_tray" region
-  And I should see "0" for the "goal" count
-  And menu item "Reports" should be "inactive"
-  And menu item "Start campaign" should be "inactive"
-  And I should not see the modal
-  And the variation edit mode is "active"
-  When I click "#site-name a span" element in the "page_content" region
-  And I wait for AJAX to finish
-  Then I should see the text "<SPAN>" in the "dialog_variation_type" region
-  When I click "Edit text" in the "dialog_variation_type" region
-  And I wait for AJAX to finish
-  Then I should not see a "#acquia-lift-modal-variation-type-select-dialog" element
-  And I should see the text "Edit text: <SPAN>" in the "dialog_variation_type_form" region
-  And the "personalize_elements_content" field should contain the site title
-  When I fill in "Lift Testing" for "personalize_elements_content"
-  And I press the "Save" button
-  And I wait for AJAX to finish
-  Then I should see the message "The variation has been created. Add one or more goals by clicking Goals > Add goal." in the messagebox
-  When I wait for AJAX to finish
-  Then I should not see the variation type form dialog
-  And I should see the text "Lift Testing"
-  And the variation edit mode is "inactive"
-  When I hover over "Goals" in the "lift_tray" region
-  Then I should see the link "Add goal" in the "lift_tray" region
-  Then I should see the link "All goals" in the "lift_tray" region
-  When I click "Add goal" in the "lift_tray" region
-  And I wait for AJAX to finish
-  Then I should see the modal with title "Add a goal"
-  And I should see the link "Predefined goal" in the "modal_content" region
-  And I should see the link "New element goal" in the "modal_content" region
-  And I should see the link "New page goal" in the "modal_content" region
-  When I click "Predefined goal" in the "modal_content" region
-  And I wait for AJAX to finish
-  Then I should see the modal with title "Add a goal"
-  And I should see the link "Change type of goal" in the "modal_content" region
-  When I click "Change type of goal" in the "modal_content" region
-  And I wait for AJAX to finish
-  Then I should see the modal with title "Add a goal"
-  And I should see the link "Predefined goal" in the "modal_content" region
-  And I should see the link "New element goal" in the "modal_content" region
-  And I should see the link "New page goal" in the "modal_content" region
-  When I click "New page goal" in the "modal_content" region
-  And I wait for AJAX to finish
-  Then I should see the modal with title "Add a goal"
-  And I should see the link "Change type of goal" in the "modal_content" region
-  When I fill in "My test goal" for "edit-title"
-  And I press "Add goal"
-  And I wait for AJAX to finish
-  Then I should see the message "My test goal goal added to campaign." in the messagebox
-  When I wait for AJAX to finish
-  Then  I should see "1" for the "goal" count
-  When I hover over "Goals" in the "lift_tray" region
-  Then I should see the text "My test goal" in the "lift_tray" region
-  When I wait for Lift to synchronize
-  Then menu item "Reports" should be "active"
-  And menu item "Start campaign" should be "active"
+  Scenario: Create the simplest A/B campaign from start to finish.
+    # I login with the marketer role.
+    Given I am logged in as a user with the "access administration pages,access toolbar,administer visitor actions,manage personalized content" permission
+    And I am on the homepage
+    When I click "Acquia Lift" in the "menu" region
+    And I wait for AJAX to finish
+    Then I should visibly see the link "Campaigns" in the "lift_tray" region
+    And I should not visibly see the link "Variation sets" in the "lift_tray" region
+    And I should not visibly see the link "Goals" in the "lift_tray" region
+    And I should not visibly see the link "Reports" in the "lift_tray" region
+    And I should not visibly see the link "Status" in the "lift_tray" region
 
-  @api @javascript @campaign
-  Scenario:  As a Marketer I want to quickly create several A/B test campaigns for later use.
-    Given I am logged in as a user with the "Marketer" role
+    # I bring up the "Create a campaign" interface.
+    When I hover over "Campaigns" in the "lift_tray" region
+    And I wait for AJAX to finish
+    Then I should see the link "Add campaign" in the "lift_tray" region
+    Then I should see the link "All campaigns" in the "lift_tray" region
+    When I click "Add campaign" in the "lift_tray" region
+    And I wait for AJAX to finish
+    Then I should see the modal with title "Create a campaign"
+    And I should see the link "A/B test" in the "modal_content" region
+    And I should see the link "Custom Lift campaign" in the "modal_content" region
+
+    # I create a simple A/B test campaign.
+    When I click "A/B test" in the "modal_content" region
+    And I wait for AJAX to finish
+    Then I should see the modal with title "Create a campaign"
+    And I should see the link "Change type of test" in the "modal_content" region
+    When I click "Change type of test" in the "modal_content" region
+    And I wait for AJAX to finish
+    Then I should see the modal with title "Create a campaign"
+    And I should see the link "A/B test" in the "modal_content" region
+    And I should see the link "Custom Lift campaign" in the "modal_content" region
+    When I click "A/B test" in the "modal_content" region
+    And I wait for AJAX to finish
+    Then I should see the modal with title "Create a campaign"
+    And I should see the link "Change type of test" in the "modal_content" region
+    When I fill in "My test campaign" for "edit-agent-basic-info-title"
+    And I press the "Create campaign" button
+    And I wait for AJAX to finish
+
+    # I verify my campaign is created.
+    Then I should see the message "Click the element you want to change in Variation #1" in the messagebox
+    Then I wait for AJAX to finish
+    When I should see the text "Campaign: My test campaign" in the "lift_tray_campaign_header" region
+    And I should visibly see the link "Variations" in the "lift_tray" region
+    And I should see "0" for the "variation" count
+    And I should visibly see the link "Goals" in the "lift_tray" region
+    And I should see "0" for the "goal" count
+    And menu item "Reports" should be "inactive"
+    And menu item "Start campaign" should be "inactive"
+    And I should not see the modal
+    And the variation edit mode is "active"
+
+    # I create a new variation.
+    When I click "#site-name a span" element in the "page_content" region
+    And I wait for AJAX to finish
+    Then I should see the text "<SPAN>" in the "dialog_variation_type" region
+    When I click "Edit text" in the "dialog_variation_type" region
+    And I wait for AJAX to finish
+    Then I should not see a "#acquia-lift-modal-variation-type-select-dialog" element
+    And I should see the text "Edit text: <SPAN>" in the "dialog_variation_type_form" region
+    And the "personalize_elements_content" field should contain the site title
+    When I fill in "Lift Testing" for "personalize_elements_content"
+    And I press the "Save" button
+    And I wait for AJAX to finish
+
+    # I verify my variation is created.
+    Then I should see the message "The variation has been created. Add one or more goals by clicking Goals > Add goal." in the messagebox
+    When I wait for AJAX to finish
+    Then I should not see the variation type form dialog
+    And I should see the text "Lift Testing"
+    And the variation edit mode is "inactive"
+
+    # I bring up the "Add goal" interface.
+    When I hover over "Goals" in the "lift_tray" region
+    Then I should see the link "Add goal" in the "lift_tray" region
+    Then I should see the link "All goals" in the "lift_tray" region
+    When I click "Add goal" in the "lift_tray" region
+    And I wait for AJAX to finish
+    Then I should see the modal with title "Add a goal"
+    And I should see the link "Predefined goal" in the "modal_content" region
+    And I should see the link "New element goal" in the "modal_content" region
+    And I should see the link "New page goal" in the "modal_content" region
+
+    # I go to "Predefined goal" sub-menu then return.
+    When I click "Predefined goal" in the "modal_content" region
+    And I wait for AJAX to finish
+    Then I should see the modal with title "Add a goal"
+    And I should see the link "Change type of goal" in the "modal_content" region
+    When I click "Change type of goal" in the "modal_content" region
+    And I wait for AJAX to finish
+
+    # I verify I am back to the "Add goal" interface.
+    Then I should see the modal with title "Add a goal"
+    And I should see the link "Predefined goal" in the "modal_content" region
+    And I should see the link "New element goal" in the "modal_content" region
+    And I should see the link "New page goal" in the "modal_content" region
+
+    # I add a new page goal.
+    When I click "New page goal" in the "modal_content" region
+    And I wait for AJAX to finish
+    Then I should see the modal with title "Add a goal"
+    And I should see the link "Change type of goal" in the "modal_content" region
+    When I fill in "My test goal" for "edit-title"
+    And I press "Add goal"
+    And I wait for AJAX to finish
+
+    # I verify my page goal is added.
+    Then I should see the message "My test goal goal added to campaign." in the messagebox
+    When I wait for AJAX to finish
+    Then I should see "1" for the "goal" count
+    When I hover over "Goals" in the "lift_tray" region
+    Then I should see the text "My test goal" in the "lift_tray" region
+
+    # I verify my campaign's status.
+    When I wait for Lift to synchronize
+    Then menu item "Reports" should be "inactive"
+    And menu item "Start campaign" should be "active"
+
+  Scenario: Create several A/B test campaigns for later use.
+    # I login with the marketer role.
+    Given I am logged in as a user with the "access administration pages,access toolbar,administer visitor actions,manage personalized content" permission
     And I am on the homepage
     When I click "Acquia Lift" in the "menu" region
     And I wait for AJAX to finish
     Then I should see the link "Campaigns" in the "lift_tray" region
+
+    # I bring up the "Create a campaign" interface.
     When I hover over "Campaigns" in the "lift_tray" region
     And I wait for AJAX to finish
     Then I should see the link "Add campaign" in the "lift_tray" region
     When I click "Add campaign" in the "lift_tray" region
     And I wait for AJAX to finish
     Then I should see the modal with title "Create a campaign"
+
+    # I create my first simple A/B test campaign.
     When I click "A/B test" in the "modal_content" region
     And I wait for AJAX to finish
     Then I should see the modal with title "Create a campaign"
     When I fill in "Test campaign 2" for "agent_basic_info[title]"
     And I press the "Create campaign" button
     And I wait for AJAX to finish
+
+    # I verify my first campaign is created.
     Then I should see the message "Click the element you want to change in Variation #1" in the messagebox
     When I wait for AJAX to finish
     Then I should see the text "Campaign: Test campaign 2" in the "lift_tray_campaign_header" region
     And the variation edit mode is "active"
+
+    # I bring up the "Create a campaign" interface, again.
     When I hover over "Campaign: Test campaign 2" in the "lift_tray" region
     And I wait for AJAX to finish
     Then I should see the link "Add campaign" in the "lift_tray" region
@@ -134,12 +162,16 @@ Scenario: Create the simplest A/B campaign from start to finish.
     And I wait for AJAX to finish
     Then I should see the modal with title "Create a campaign"
     And the variation edit mode is "disabled"
+
+    # I create my second simple A/B test campaign.
     When I click "A/B test" in the "modal_content" region
     And I wait for AJAX to finish
     Then I should see the modal with title "Create a campaign"
     When I fill in "Test campaign 3" for "agent_basic_info[title]"
     And I press the "Create campaign" button
     And I wait for AJAX to finish
+
+    # I verify my second campaign is created.
     Then I should see the message "Click the element you want to change in Variation #1" in the messagebox
     When I wait for AJAX to finish
     Then I should see the text "Campaign: Test campaign 3" in the "lift_tray_campaign_header" region

--- a/behat-tests/features/admin_tray_access.feature
+++ b/behat-tests/features/admin_tray_access.feature
@@ -1,22 +1,19 @@
-# Assumes roles: Marketer, Nonmarketer
-
+@api @insulated
 Feature: Access to the Acquia Lift tray controls.
   In order to protect site content
   As a Lift engineer
   I want to ensure that only authorized users have access to the lift tray.
 
-  Scenario: I should not see the Lift controls when not authorized.
+  Scenario: I should not see the Lift controls when I am anonymous.
     Given I am an anonymous user
     And I am on the homepage
     Then the response should not contain "admin/acquia_lift"
 
-  @api
   Scenario: I should see the Lift controls when authorized.
-    Given I am logged in as a user with the "Marketer" role
+    Given I am logged in as a user with the "access administration pages,access toolbar,administer visitor actions,manage personalized content" permission
     And I am on the homepage
     Then I should see the link "Acquia Lift" in the "menu" region
 
-  @api
   Scenario: I should not see the Lift controls when unauthorized.
-    Given I am logged in as a user with the "Nonmarketer" role
+    Given I am logged in as a user with the "access administration pages,access toolbar" permission
     Then I should not see the link "Acquia Lift" in the "menu" region

--- a/behat-tests/features/bootstrap/FeatureContext.php
+++ b/behat-tests/features/bootstrap/FeatureContext.php
@@ -624,11 +624,9 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
    *   The element node for the link or null if not found.
    */
   private function findLinkInRegion($link, $region) {
-    $session = $this->getSession();
     $regionObj = $this->getRegion($region);
-    $xpath = $session->getSelectorsHandler()->selectorToXpath('link', $link);
+    $element = $regionObj->findLink($link);
 
-    $element = $regionObj->find('xpath', $xpath);
     if (empty($element)) {
       throw new \Exception(sprintf('Could not find element in %region using xpath %s', $region, $xpath));
     }

--- a/behat-tests/features/bootstrap/FeatureContext.php
+++ b/behat-tests/features/bootstrap/FeatureContext.php
@@ -402,6 +402,20 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
   }
 
   /**
+   * @Then the :field field should contain text that has :needle
+   *
+   * @throws \Exception
+   *   If the the substring cannot be found in the given field.
+   */
+  public function assertFieldContains($field, $needle) {
+    $node = $this->assertSession()->fieldExists($field);
+    $haystack = $node->getValue();
+    if (strpos($haystack, $needle) === false) {
+      throw new \Exception(sprintf('The field "%s" value is "%s", but we are looking for "%s".', $field, $haystack, $needle));
+    }
+  }
+
+  /**
    * @Then I should see :selector element in the :region region is :state for editing
    *
    * @throws \Exception
@@ -542,14 +556,6 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
     if (strpos($message, $text) === FALSE) {
       throw new \Exception(sprintf('The message "%s" was not found in the messagebox.', $text));
     }
-  }
-
-  /**
-   * @Then I wait for :seconds seconds
-   */
-  public function iWaitSeconds($seconds) {
-    $ms = $seconds * 1000;
-    $this->getSession()->wait($ms);
   }
 
   /****************************************************

--- a/behat-tests/features/bootstrap/FeatureContext.php
+++ b/behat-tests/features/bootstrap/FeatureContext.php
@@ -794,9 +794,9 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
    * @param integer $attemptThreshold Number of attempts to execute the command.
    */
   private function spinJavaScriptEvaluation($assertionScript, $attemptThreshold = 15) {
-    $this->spin(function () use ($assertionScript, $attemptThreshold) {
+    $this->spin(function () use ($assertionScript) {
       return $this->getMink()->getSession()->evaluateScript($assertionScript);
-    });
+    }, $attemptThreshold);
   }
 
   /**

--- a/behat-tests/features/bootstrap/FeatureContext.php
+++ b/behat-tests/features/bootstrap/FeatureContext.php
@@ -397,8 +397,8 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
   public function assertFieldHasSiteTitle($field) {
     // Read the site name dynamically.
     $site_name = variable_get('site_name', "Default site name");
-    $mink = $this->getMink();
-    $mink->assertSession()->fieldValueEquals($field, $site_name);
+    $mink_context = $this->contexts['Drupal\DrupalExtension\Context\MinkContext'];
+    $mink_context->assertFieldContains($field, $site_name);
   }
 
   /**


### PR DESCRIPTION
1) Fixing behat tests. 
2) Removing role dependancy on 'Marketer' and 'Nonmarketer'. 
3) Add comments to organize behat steps into 'user action' blocks. 
4) Add '@insulated' tag to keep sessions and cookies discontinous between scenarios. 
5) Added the ability for the FeatureContext to reuse all contexts. 
6) Update code and readme documentation.
7) Introducing spin functions. 
8) Gearing up local context's actions and assertions with spin functions.
9) Removing 'I wait for AJAX to finish' step as much as possible from features.
