### PR TITLE
Ch 1968: Review screen

### DIFF
--- a/acquia_lift.admin.wizard.inc
+++ b/acquia_lift.admin.wizard.inc
@@ -160,13 +160,6 @@ function acquia_lift_personalize_campaign_wizard_variations_alter(&$form, &$form
     $form['variations']['option_sets']['option_set_' . $option_set->osid]['advanced']['label']['#access'] = FALSE;
   }
 
-  // Test to see if the current agent supports multiple variation sets.
-  if (!empty($option_sets)) {
-    if (!$agent_instance->supportsMultipleDecisionPoints()) {
-      return;
-    }
-  }
-
   // Show the card to add a new option set last.
   module_load_include('inc', 'acquia_lift', 'acquia_lift.ui');
   $option_set_types = acquia_lift_option_set_types_ui();

--- a/acquia_lift.admin.wizard.inc
+++ b/acquia_lift.admin.wizard.inc
@@ -573,6 +573,27 @@ function acquia_lift_personalize_campaign_wizard_targeting_alter(&$form, &$form_
 }
 
 /**
+ * Alter hook for the review portion of the campaign wizard.
+ */
+function acquia_lift_personalize_campaign_wizard_review_alter(&$form, &$form_state, $form_id) {
+  // Add audiences to the summary section.
+  $count = 0;
+  $form['summary']['audiences'] = array(
+    '#markup' => theme('personalize_wizard_summary_count', array(
+      'count' => $count,
+      'details' => theme('html_tag', array(
+        'element' => array(
+          '#tag' => 'h3',
+          '#value' => format_plural($count, 'Audience', 'Audiences'),
+        ),
+      )),
+    )),
+  );
+  // Move the scheduling summary element to the bottom.
+  $form['summary']['scheduling']['#weight'] = 10;
+}
+
+/**
  ********************************************************************
  *
  * A J A X  C A L L B A C K S

--- a/acquia_lift.admin.wizard.inc
+++ b/acquia_lift.admin.wizard.inc
@@ -569,9 +569,13 @@ function acquia_lift_personalize_campaign_wizard_targeting_alter(&$form, &$form_
  * Alter hook for the review portion of the campaign wizard.
  */
 function acquia_lift_personalize_campaign_wizard_review_alter(&$form, &$form_state, $form_id) {
-  // Add audiences to the summary section.
+  // Make the overview a card.
+  $form['review']['summary_column']['summary']['#type'] = 'container';
+  $form['review']['summary_column']['summary']['#theme'] = 'acquia_lift_card';
+
+    // Add audiences to the summary section.
   $count = 0;
-  $form['summary']['audiences'] = array(
+  $form['review']['summary_column']['summary']['audiences'] = array(
     '#markup' => theme('personalize_wizard_summary_count', array(
       'count' => $count,
       'details' => theme('html_tag', array(
@@ -583,7 +587,13 @@ function acquia_lift_personalize_campaign_wizard_review_alter(&$form, &$form_sta
     )),
   );
   // Move the scheduling summary element to the bottom.
-  $form['summary']['scheduling']['#weight'] = 10;
+  $form['review']['summary_column']['summary']['scheduling']['#weight'] = 10;
+
+  // Move the warnings into a card.
+  if (!empty($form['review']['warnings_column'])) {
+    $form['review']['warnings_column']['warnings']['#type'] = 'container';
+    $form['review']['warnings_column']['warnings']['#theme'] = 'acquia_lift_card';
+  }
 }
 
 /**

--- a/acquia_lift.admin.wizard.inc
+++ b/acquia_lift.admin.wizard.inc
@@ -887,6 +887,10 @@ function acquia_lift_personalize_campaign_wizard_variations_submit(&$form, &$for
   unset($form_state['redirect']);
   // Set the clicked button ID back.
   $form_state['clicked_button']['#id'] = $click_id;
+
+  // Handle the advanced settings form submission.
+  module_load_include('inc', 'personalize', 'personalize.admin.campaign');
+  personalize_campaign_wizard_submit_variations_advanced_agent($form, $form_state, $agent_data);
 }
 
 /**

--- a/acquia_lift.module
+++ b/acquia_lift.module
@@ -3147,7 +3147,8 @@ function acquia_lift_agent_verification_cache_get($agent_name) {
     }
   }
   if (!isset($verification[$agent_name])) {
-    $verification[$agent_name] = personalize_verify_agent($agent_name, FALSE);
+    $errors = personalize_verify_agent($agent_name, FALSE);
+    $verification[$agent_name] = empty($errors);
     cache_set(ACQUIA_LIFT_AGENT_VERIFY_CACHE, $verification);
   }
   return $verification[$agent_name];

--- a/css/acquia_lift.admin.css
+++ b/css/acquia_lift.admin.css
@@ -414,3 +414,11 @@ tr.acquia-lift-report-control {
   float: right;
   display: inline-block;
 }
+
+/* Review warning list */
+#personalize-campaign-wizard .personalize-wizard-review-warnings li {
+  list-style-type: none;
+  background: transparent url(../images/FF8000/alert.png) no-repeat 0 50%;
+  margin: 1em 1em 1em -15px;
+  padding-left: 40px;
+}

--- a/plugins/agent_types/AcquiaLiftAgent.inc
+++ b/plugins/agent_types/AcquiaLiftAgent.inc
@@ -75,10 +75,6 @@ interface AcquiaLiftAgentInterface {
   public function buildConversionReport($options);
 }
 
-interface AcquiaLiftSimplifiedAgentInterface {
-  public static function simplifiedForm($agent_data);
-}
-
 /**
  * An interface to implement when an agent handles page-level variations such
  * as a simple A/B test.
@@ -274,180 +270,6 @@ class AcquiaLiftAgent extends PersonalizeAgentBase implements PersonalizeAgentGo
    */
   public function sendGoal($goal_name, $value = NULL) {
     // @todo Implement server-side goal delivery.
-  }
-
-  /**
-   * Implements PersonalizeAgentInterface::optionsForm().
-   */
-  public static function optionsForm($agent_data, $option_parents = array()) {
-    return self::buildOptionsForm($agent_data, FALSE, $option_parents);
-  }
-
-  /**
-   * Builds the options to display for a campaign form.
-   *
-   * @param $agent_data
-   *   The existing campaign data.
-   * @param bool $simplified
-   *   Indicates if the form should be shown in simplified format or with all
-   *   advanced options.
-   *
-   * @return array
-   *   The form render array.
-   */
-  protected static function buildOptionsForm($agent_data, $simplified = FALSE, $option_parents = array()) {
-    $account_info = variable_get('acquia_lift_account_info', array());
-    if (empty($account_info)) {
-      drupal_set_message(t('Your Acquia Lift account info has not been configured. Any Acquia Lift campaigns you create here will not work until you configure your account info !here', array('!here' => l('here', 'admin/config/content/personalize/acquia_lift'))), 'error');
-    }
-    $form = array();
-    $form['#attached'] = array(
-      'css' => array(
-        drupal_get_path('module', 'acquia_lift') . '/css/personalize_acquia_lift_admin.css',
-        drupal_get_path('module', 'acquia_lift') . '/css/acquia_lift.admin.css',
-      ),
-      'js' => array(
-        drupal_get_path('module', 'acquia_lift') . '/js/acquia_lift.agent.admin.js',
-      ),
-    );
-    if (empty($option_parents)) {
-      $option_parents = array('agent_basic_info', 'options', 'acquia_lift');
-    }
-
-    $control_rate = isset($agent_data->data['control_rate']) ? $agent_data->data['control_rate'] : 10;
-    if ($simplified) {
-      $form['control_rate'] = array(
-        '#type' => 'value',
-        '#value' => $control_rate,
-      );
-    }
-    else {
-      $form['control'] = array(
-        '#type' => 'fieldset',
-        '#tree' => FALSE,
-        '#collapsible' => TRUE,
-        '#collapsed' => TRUE,
-        '#title' => t('Control (@control_rate%)', array('@control_rate' => $control_rate)),
-      );
-      $control_rate_parents = $option_parents;
-      $control_rate_parents[] = 'control_rate';
-      $form['control']['control_rate'] = array(
-        '#type' => 'acquia_lift_percentage',
-        '#parents' => $control_rate_parents,
-        '#title' => t('Control Group'),
-        '#field_suffix' => '%',
-        '#size' => 3,
-        '#description' => t('A fixed baseline variation will be shown, by default the first variation in the set.'),
-        '#default_value' => $control_rate,
-        '#rest_title' => t('Test Group'),
-        '#rest_description' => t('Personalized variations will be shown.'),
-        '#collapsible' => TRUE,
-        '#collapsed' => TRUE,
-      );
-    }
-    $decision_style = isset($agent_data->data['decision_style']) ? $agent_data->data['decision_style'] : 'adaptive';
-    if ($simplified) {
-      $form['decision_style'] = array(
-        '#type' => 'value',
-        '#value' => $decision_style,
-      );
-    }
-    else {
-      $form['decision_style'] = array(
-        '#type' => 'radios',
-        '#title' => t('Decision Style'),
-        '#options' => array('adaptive' => t('Auto-personalize'), 'random' => t('Test only')),
-        '#default_value' => $decision_style,
-        '#title_display' => 'invisible',
-      );
-      $form['decision_style']['adaptive'] = array(
-        '#description' => t('Adapts to users and chooses the best option over time.'),
-      );
-      $form['decision_style']['random'] = array(
-        '#description' => t('Tests variations and reports results.'),
-      );
-    }
-    $explore_rate = isset($agent_data->data['explore_rate']) ? $agent_data->data['explore_rate'] : 20;
-    if ($simplified) {
-      $form['distribution'] = array(
-        '#type' => 'value',
-        '#value' => $explore_rate,
-      );
-    }
-    else {
-      $decision_style_parents = $option_parents;
-      $decision_style_parents[] = 'decision_style';
-      $decision_style_form_element = '';
-      foreach ($decision_style_parents as $i => $parent_name) {
-        $decision_style_form_element .= ($i ? '[' . $parent_name . ']' : $parent_name);
-      }
-      $form['distribution'] = array(
-        '#type' => 'fieldset',
-        '#tree' => FALSE,
-        '#collapsible' => TRUE,
-        '#collapsed' => TRUE,
-        '#title' => t('Distribution (@explore_rate/@rest)', array(
-          '@explore_rate' => $explore_rate,
-          '@rest' => (100 - $explore_rate),
-        )),
-        '#states' => array(
-          'visible' => array(
-            ':input[name="' . $decision_style_form_element . '"]' => array('value' => 'adaptive'),
-          ),
-        ),
-      );
-      $explore_rate_parents = $option_parents;
-      $explore_rate_parents[] = 'explore_rate';
-      $form['distribution']['explore_rate'] = array(
-        '#type' => 'acquia_lift_percentage',
-        '#parents' => $explore_rate_parents,
-        '#title' => t('Random Group'),
-        '#field_suffix' => '%',
-        '#description' => t('Variations will be shown randomly and tracked to adjust for false positives.'),
-        '#size' => 3,
-        '#default_value' => isset($agent_data->data['explore_rate']) ? $agent_data->data['explore_rate'] : 20,
-        '#rest_title' => t('Personalized Group'),
-        '#rest_description' => t('The "best" variation will be shown for each visitor based on our algorithm.'),
-        '#collapsible' => TRUE,
-        '#collapsed' => TRUE,
-      );
-    }
-    // This will get overridden by the 'campaign_end' dropdown.
-    $form['auto_stop'] = array(
-      '#type' => 'value',
-      '#value' => 0
-    );
-    return $form;
-  }
-
-  /**
-   * Implements PersonalizeAgentInterface::optionsFormValidate().
-   */
-  public static function optionsFormValidate($form, &$form_state, $option_parents = array()) {
-    $values = &$form_state['values'];
-    foreach($option_parents as $parent) {
-      $values = &$values[$parent];
-    }
-    $error_parents = implode('][', $option_parents);
-    if (isset($values['control_rate'])) {
-      $rate = $values['control_rate'];
-      if (!is_numeric($rate) || !($rate >= 0 && $rate <= 100)) {
-        $error_element = empty($error_parents) ? 'control_rate' : $error_parents . '][contral_rate';
-        form_set_error($error_element, t('Invalid percent to test specified'));
-      }
-    }
-    if (isset($values['explore_rate'])) {
-      $rate = $values['explore_rate'];
-      if (!is_numeric($rate) || !($rate >= 0 && $rate <= 100)) {
-        $error_element = empty($error_parents) ? 'explore_rate' : $error_parents . '][explore_rate';
-        form_set_error($error_element, t('Invalid percent to test specified'));
-      }
-    }
-    // If "Run until a winner is found" was selected, we need to add this to the agent's
-    // data property.
-    if (isset($form_state['values']['campaign_end']) && $form_state['values']['campaign_end'] == 'auto') {
-      $values['auto_stop'] = 1;
-    }
   }
 
   /**
@@ -1124,14 +946,7 @@ class AcquiaLiftAgent extends PersonalizeAgentBase implements PersonalizeAgentGo
  * differs from the regular Acquia Lift agent class in the options form it presents
  * to users.
  */
-class AcquiaLiftSimpleAB extends AcquiaLiftAgent implements AcquiaLiftSimplifiedAgentInterface, AcquiaLiftPageVariationInterface, PersonalizeAutoTargetingInterface {
-
-  /**
-   * Implements PersonalizeAgentInterface::optionsForm().
-   */
-  public static function simplifiedForm($agent_data) {
-    return self::buildOptionsForm($agent_data, TRUE);
-  }
+class AcquiaLiftSimpleAB extends AcquiaLiftAgent implements AcquiaLiftPageVariationInterface, PersonalizeAutoTargetingInterface {
 
   /**
    * Implements PersonalizeAgentInterface::supportsMVTs().

--- a/tests/acquia_lift.test
+++ b/tests/acquia_lift.test
@@ -3039,7 +3039,7 @@ class AcquiaLiftWebTestWorkflow extends AcquiaLiftWebTestBase {
     $this->drupalPost('admin/structure/personalize', array(), t('Start'), array(), array(), $html_id_first_agent);
 
     // As soon as the agent is started, we are able to access its reports.
-    $expected[$first_agent_machine_name]['links']['report'] = url('admin/structure/personalize/manage/' . $first_agent_machine_name . '/report');
+    $expected[$first_agent_machine_name]['links']['report'] = url('admin/structure/personalize/manage/' . $first_agent_machine_name . '/results');
     $expected[$first_agent_machine_name]['status'] = PERSONALIZE_STATUS_RUNNING;
     $expected[$first_agent_machine_name]['nextStatus'] = array(
       'status' => PERSONALIZE_STATUS_PAUSED,

--- a/tests/acquia_lift.test
+++ b/tests/acquia_lift.test
@@ -1264,7 +1264,8 @@ class AcquiaLiftWebTestAgentAdmin extends AcquiaLiftWebTestBase {
               ),
             )
           )
-        )
+        ),
+        'cache_decisions' => 0,
       )
     );
     personalize_campaign_wizard_submit(array(), $form_state);
@@ -1862,7 +1863,7 @@ class AcquiaLiftWebTestFundamentals extends AcquiaLiftWebTestBase {
     $edit = array(
       'cache_decisions' => FALSE
     );
-    $this->drupalPost("admin/structure/personalize/manage/$machine_name/review", $edit, $this->getButton('wizard_start'));
+    $this->drupalPost("admin/structure/personalize/manage/$machine_name/variations", $edit, $this->getButton('wizard_start'));
     personalize_agent_set_status($machine_name, PERSONALIZE_STATUS_PAUSED);
     $this->resetAll();
     $queued_agent_item['args'][6] = FALSE;

--- a/tests/acquia_lift.test
+++ b/tests/acquia_lift.test
@@ -129,13 +129,12 @@ class AcquiaLiftWebTestBase extends DrupalWebTestCase
     $this->drupalPost('admin/structure/personalize/add', $edit, $this->getButton('create_campaign'));
 
     if (!$basicOnly) {
-      $edit = array(
-        'agent_options[options][decision_style]' => $data['decision_style'],
-        'agent_options[options][control_rate]' => $data['control_rate'],
-        'agent_options[options][explore_rate]' => $data['explore_rate'],
-        'cache_decisions' => $data['cache_decisions']
-      );
-      $this->drupalPost('admin/structure/personalize/manage/' . $data['machine_name'] . '/review', $edit, $this->getButton('wizard_start'));
+      $agent_data = personalize_agent_load($data['machine_name']);
+      $agent_data->data['decision_style'] = $data['decision_style'];
+      $agent_data->data['control_rate'] = $data['control_rate'];
+      $agent_data->data['explore_rate'] = $data['explore_rate'];
+      $agent_data->data['cache_decisions'] = $data['cache_decisions'];
+      personalize_agent_save($agent_data);
     }
 
     if ($data['auto_stop']) {


### PR DESCRIPTION
- Removing optionsForm and optionsFormValidate from agent interface
- Move advanced agent settings in "What" subform
- Formatting of review screen info to match rest of Acquia Lift screens.
- Fix affected test

There are still plenty of test failures - but they all are involved in the queue stuff and I figure that's all being redone anyway.
