### PR TITLE
CH-2394 Boxing up all 'identity' parameters.

### DIFF
--- a/acquia_lift_profiles/acquia_lift_profiles.admin.inc
+++ b/acquia_lift_profiles/acquia_lift_profiles.admin.inc
@@ -50,7 +50,8 @@ function acquia_lift_profiles_admin_form($form, &$form_state) {
 
   $identity_parameter_display_value = variable_get('acquia_lift_profiles_identity_param') ?: 'identity';
   $identity_type_parameter_display_value = variable_get('acquia_lift_profiles_identity_type_param') ?: 'identityType';
-  $default_identity_type_display_value = variable_get('acquia_lift_profiles_default_identity_type') ?: ACQUIA_LIFT_PROFILES_DEFAULT_IDENTITY_TYPE_DEFAULT;
+  $default_identity_type_display_value = variable_get('acquia_lift_profiles_default_identity_type') ?: 'account';
+  $default_identity_type_default_value = variable_get('acquia_lift_profiles_default_identity_type') ?: ACQUIA_LIFT_PROFILES_DEFAULT_IDENTITY_TYPE_DEFAULT;
   $form['acquia_lift_profiles_identity'] = array(
     '#title' => t('Identity'),
     '#type' => 'fieldset',
@@ -65,7 +66,7 @@ function acquia_lift_profiles_admin_form($form, &$form_state) {
   $form['acquia_lift_profiles_identity']['acquia_lift_profiles_identity_param'] = array(
     '#type' => 'textfield',
     '#title' => t('Identity parameter'),
-    '#description' => t('The query string parameter for a specific item of visitor information, such as the visitor\'s email address or social media username. This identification info is sent to Acquia Lift Web only if this parameter is explicitly configured here. (Example: ?<ins>@identity_parameter_display_value</ins>=person@example.com)', array(
+    '#description' => t('The query string parameter for specific visitor information, such as an email address or social media username, which is sent to the Acquia Lift service. Example: ?<ins>@identity_parameter_display_value</ins>=jdoe01', array(
       '@identity_parameter_display_value' => $identity_parameter_display_value,
     )),
     '#default_value' => variable_get('acquia_lift_profiles_identity_param', ''),
@@ -73,10 +74,11 @@ function acquia_lift_profiles_admin_form($form, &$form_state) {
   $form['acquia_lift_profiles_identity']['acquia_lift_profiles_identity_type_param'] = array(
     '#type' => 'textfield',
     '#title' => t('Identity type parameter'),
-    '#description' => t('The query string parameter for the category of the visitor\'s identity information. Acquia Lift Web by default accepts "email", "account", "facebook", "twitter", and "name", and you can add more in the Web\'s interface before using them here. (Example: ?@identity_parameter_display_value=person@example.com&<ins>@identity_type_parameter_display_value</ins>=@default_identity_type_display_value)', array(
+    '#description' => t('The query string parameter for the category (standard or custom) of the visitor\'s identity information, as defined in the !help_link. Example: ?@identity_parameter_display_value=jdoe01&<ins>@identity_type_parameter_display_value</ins>=@default_identity_type_default_value', array(
       '@identity_parameter_display_value' => $identity_parameter_display_value,
       '@identity_type_parameter_display_value' => $identity_type_parameter_display_value,
-      '@default_identity_type_display_value' => $default_identity_type_display_value,
+      '@default_identity_type_default_value' => $default_identity_type_default_value,
+      '!help_link' => l(t('Acquia Lift service'), 'https://docs.acquia.com/lift/recommend/admin/customer#custom-identifier', array('attributes' => array('target' => '_blank'))),
     )),
     '#default_value' => variable_get('acquia_lift_profiles_identity_type_param', ''),
     '#states' => array(
@@ -91,7 +93,7 @@ function acquia_lift_profiles_admin_form($form, &$form_state) {
     '#attributes' => array(
       'placeholder' => ACQUIA_LIFT_PROFILES_DEFAULT_IDENTITY_TYPE_DEFAULT,
     ),
-    '#description' => t('The identity type\'s default value, which will be used if the identity type parameter is absent in the query string. If this value is not explicitly configured, "@default" will be used. (Example: ?@identity_parameter_display_value=person@example.com&@identity_type_parameter_display_value=<ins>@default_identity_type_display_value</ins> is the same as ?@identity_parameter_display_value=person@example.com)', array(
+    '#description' => t('The identity type category to use by default. Leave this field blank to default to <ins>@default</ins>. Example: <ins>@default_identity_type_display_value</ins> is "?@identity_parameter_display_value=jdoe01&@identity_type_parameter_display_value=<ins>@default_identity_type_display_value</ins>", while blank is the same as "?@identity_parameter_display_value=jdoe01&@identity_type_parameter_display_value=<ins>@default</ins>"', array(
       '@default' => ACQUIA_LIFT_PROFILES_DEFAULT_IDENTITY_TYPE_DEFAULT,
       '@identity_parameter_display_value' => $identity_parameter_display_value,
       '@identity_type_parameter_display_value' => $identity_type_parameter_display_value,

--- a/acquia_lift_profiles/acquia_lift_profiles.admin.inc
+++ b/acquia_lift_profiles/acquia_lift_profiles.admin.inc
@@ -48,16 +48,21 @@ function acquia_lift_profiles_admin_form($form, &$form_state) {
     '#required' => TRUE,
   );
 
-  $form['acquia_lift_profiles_capture_identity'] = array(
+  $identity_parameter_display_value = variable_get('acquia_lift_profiles_identity_param') ?: 'identity';
+  $identity_type_parameter_display_value = variable_get('acquia_lift_profiles_identity_type_param') ?: 'identityType';
+  $default_identity_type_display_value = variable_get('acquia_lift_profiles_default_identity_type') ?: ACQUIA_LIFT_PROFILES_DEFAULT_IDENTITY_TYPE_DEFAULT;
+  $form['acquia_lift_profiles_identity'] = array(
+    '#title' => t('Identity'),
+    '#type' => 'fieldset',
+    '#tree' => TRUE,
+  );
+  $form['acquia_lift_profiles_identity']['acquia_lift_profiles_capture_identity'] = array(
     '#type' => 'checkbox',
     '#title' => t('Capture identity on login / register'),
     '#description' => t('Check this if you want Acquia Lift Profiles to capture the identity of the user upon login or registration. This means sending their email address to the Acquia Lift Profile Manager.'),
     '#default_value' => variable_get('acquia_lift_profiles_capture_identity', FALSE),
   );
-  $identity_parameter_display_value = variable_get('acquia_lift_profiles_identity_param') ?: 'identity';
-  $identity_type_parameter_display_value = variable_get('acquia_lift_profiles_identity_type_param') ?: 'identityType';
-  $default_identity_type_display_value = variable_get('acquia_lift_profiles_default_identity_type') ?: ACQUIA_LIFT_PROFILES_DEFAULT_IDENTITY_TYPE_DEFAULT;
-  $form['acquia_lift_profiles_identity_param'] = array(
+  $form['acquia_lift_profiles_identity']['acquia_lift_profiles_identity_param'] = array(
     '#type' => 'textfield',
     '#title' => t('Identity parameter'),
     '#description' => t('The query string parameter for a specific item of visitor information, such as the visitor\'s email address or social media username. This identification info is sent to Acquia Lift Web only if this parameter is explicitly configured here. (Example: ?<ins>@identity_parameter_display_value</ins>=person@example.com)', array(
@@ -65,7 +70,7 @@ function acquia_lift_profiles_admin_form($form, &$form_state) {
     )),
     '#default_value' => variable_get('acquia_lift_profiles_identity_param', ''),
   );
-  $form['acquia_lift_profiles_identity_type_param'] = array(
+  $form['acquia_lift_profiles_identity']['acquia_lift_profiles_identity_type_param'] = array(
     '#type' => 'textfield',
     '#title' => t('Identity type parameter'),
     '#description' => t('The query string parameter for the category of the visitor\'s identity information. Acquia Lift Web by default accepts "email", "account", "facebook", "twitter", and "name", and you can add more in the Web\'s interface before using them here. (Example: ?@identity_parameter_display_value=person@example.com&<ins>@identity_type_parameter_display_value</ins>=@default_identity_type_display_value)', array(
@@ -76,11 +81,11 @@ function acquia_lift_profiles_admin_form($form, &$form_state) {
     '#default_value' => variable_get('acquia_lift_profiles_identity_type_param', ''),
     '#states' => array(
       'visible' => array(
-        ':input[name="acquia_lift_profiles_identity_param"]' =>  array('!value' => '')
+        ':input[name="acquia_lift_profiles_identity[acquia_lift_profiles_identity_param]"]' => array('!value' => '')
       )
     )
   );
-  $form['acquia_lift_profiles_default_identity_type'] = array(
+  $form['acquia_lift_profiles_identity']['acquia_lift_profiles_default_identity_type'] = array(
     '#type' => 'textfield',
     '#title' => t('Default identity type'),
     '#attributes' => array(
@@ -212,7 +217,7 @@ function acquia_lift_profiles_admin_form_submit($form, &$form_state) {
   // If the "capture identity" setting has changed we need to make sure the visitor
   // actions subscribers are cleared for the login and register actions.
   $capture_identity = variable_get('acquia_lift_profiles_capture_identity', FALSE);
-  if ($capture_identity != $form_state['values']['acquia_lift_profiles_capture_identity']) {
+  if ($capture_identity != $form_state['values']['acquia_lift_profiles_identity']['acquia_lift_profiles_capture_identity']) {
     visitor_actions_clear_subscribers('user_login');
     visitor_actions_clear_subscribers('user_register');
   }
@@ -221,15 +226,21 @@ function acquia_lift_profiles_admin_form_submit($form, &$form_state) {
     'acquia_lift_profiles_site_name',
     'acquia_lift_profiles_access_key',
     'acquia_lift_profiles_secret_key',
-    'acquia_lift_profiles_capture_identity',
-    'acquia_lift_profiles_identity_param',
-    'acquia_lift_profiles_identity_type_param',
-    'acquia_lift_profiles_default_identity_type',
     'acquia_lift_profiles_vocabulary_mappings'
   );
   foreach ($variables as $key) {
     variable_set($key, $form_state['values'][$key]);
   }
+  $identity_variables = array(
+    'acquia_lift_profiles_capture_identity',
+    'acquia_lift_profiles_identity_param',
+    'acquia_lift_profiles_identity_type_param',
+    'acquia_lift_profiles_default_identity_type',
+  );
+  foreach ($identity_variables as $key) {
+    variable_set($key, $form_state['values']['acquia_lift_profiles_identity'][$key]);
+  }
+
   // Strip out any http/https protocol from urls and save.
   foreach (array('acquia_lift_profiles_api_url', 'acquia_lift_profiles_js_path') as $key) {
     variable_set($key, preg_replace('/(^[a-z]+:\/\/)/i', '', $form_state['values'][$key]));

--- a/acquia_lift_profiles/tests/acquia_lift_profiles.test
+++ b/acquia_lift_profiles/tests/acquia_lift_profiles.test
@@ -91,7 +91,7 @@ class ALProfilesWebTest extends DrupalWebTestCase {
     // Login as admin again and set the "capture identity" setting.
     $this->drupalLogin($this->admin_user);
     $edit = array(
-      'acquia_lift_profiles_capture_identity' => TRUE,
+      'acquia_lift_profiles_identity[acquia_lift_profiles_capture_identity]' => TRUE,
     );
     $this->drupalPost('admin/config/content/personalize/acquia_lift_profiles', $edit, t('Save'));
     $this->drupalLogout();
@@ -222,7 +222,9 @@ class ALProfilesWebTest extends DrupalWebTestCase {
     $this->configureALProfiles();
     $this->drupalLogin($this->admin_user);
     // Test specifying a querystring param to use for capturing identity.
-    $this->drupalPost('admin/config/content/personalize/acquia_lift_profiles', array('acquia_lift_profiles_identity_param' => 'ali'), t('Save'));
+    $this->drupalPost('admin/config/content/personalize/acquia_lift_profiles', array(
+      'acquia_lift_profiles_identity[acquia_lift_profiles_identity_param]' => 'ali',
+    ), t('Save'));
     $this->drupalLogout();
 
     // Now visit the site as anon without passing any querystring params.
@@ -241,7 +243,9 @@ class ALProfilesWebTest extends DrupalWebTestCase {
 
     // Set the identity type param
     $this->drupalLogin($this->admin_user);
-    $this->drupalPost('admin/config/content/personalize/acquia_lift_profiles', array('acquia_lift_profiles_identity_type_param' => 'alit'), t('Save'));
+    $this->drupalPost('admin/config/content/personalize/acquia_lift_profiles', array(
+      'acquia_lift_profiles_identity[acquia_lift_profiles_identity_type_param]' => 'alit',
+    ), t('Save'));
     $this->drupalLogout();
 
     // Pass the configured identity param and the identity_type param
@@ -262,7 +266,9 @@ class ALProfilesWebTest extends DrupalWebTestCase {
     // Set the default identity type
     $default_type = 'tknr';
     $this->drupalLogin($this->admin_user);
-    $this->drupalPost('admin/config/content/personalize/acquia_lift_profiles', array('acquia_lift_profiles_default_identity_type' => $default_type), t('Save'));
+    $this->drupalPost('admin/config/content/personalize/acquia_lift_profiles', array(
+      'acquia_lift_profiles_identity[acquia_lift_profiles_default_identity_type]' => $default_type,
+    ), t('Save'));
     $this->drupalLogout();
 
     // Pass the configured identity param but without the identity_type param


### PR DESCRIPTION
As per mid-sprint review, we are now grouping all 4 identity parameters together in UI.
