### PR TITLE
Ch 1963: Move actions into a ctools dropdown button

### DIFF
--- a/acquia_lift.admin.inc
+++ b/acquia_lift.admin.inc
@@ -1196,19 +1196,6 @@ function acquia_lift_validate_minimum_targeting($agent, $option_set) {
 }
 
 /**
- * Page callback to set the status of an acquia lift targeting agent
- *
- * @param stdClass $agent_data
- *   The agent to update and synchronize if necessary.
- * @param $next_status
- *   The new status for the agent.
- */
-function acquia_lift_target_status_callback($agent_data, $next_status) {
-  acquia_lift_target_set_status($agent_data, $next_status);
-  drupal_goto(url('admin/structure/personalize/manage/' . $agent_data->machine_name . '/review'));
-}
-
-/**
  * Update the status of an acquia lift target agent and synchronize any
  * necessary configuration to Lift.
  *

--- a/acquia_lift.admin.inc
+++ b/acquia_lift.admin.inc
@@ -1195,6 +1195,60 @@ function acquia_lift_validate_minimum_targeting($agent, $option_set) {
   acquia_lift_save_targeting_structure($agent, array(ACQUIA_LIFT_TARGETING_EVERYONE_ELSE => $unassigned_options));
 }
 
+/**
+ * Page callback to set the status of an acquia lift targeting agent
+ *
+ * @param stdClass $agent_data
+ *   The agent to update and synchronize if necessary.
+ * @param $next_status
+ *   The new status for the agent.
+ */
+function acquia_lift_target_status_callback($agent_data, $next_status) {
+  acquia_lift_target_set_status($agent_data, $next_status);
+  drupal_goto(url('admin/structure/personalize/manage/' . $agent_data->machine_name . '/review'));
+}
+
+/**
+ * Update the status of an acquia lift target agent and synchronize any
+ * necessary configuration to Lift.
+ *
+ * @param stdClass $agent_data
+ *   The agent to update and synchronize if necessary.
+ * @param $next_status
+ *   The new status for the agent.
+ * @return bool
+ *   True if the synchronization and status changes were successful.
+ */
+function acquia_lift_target_set_status($agent_data, $next_status) {
+  if ($agent_data->plugin !== 'acquia_lift_target') {
+    personalize_agent_set_status($agent_data->machine_name, $next_status);
+    return TRUE;
+  }
+  if ($next_status == PERSONALIZE_STATUS_RUNNING || $next_status == PERSONALIZE_STATUS_SCHEDULED) {
+    module_load_include('inc', 'acquia_lift', 'acquia_lift.batch');
+    try {
+      $agent_data->tests_to_delete = acquia_lift_implement_test_structure($agent_data);
+      if (acquia_lift_batch_sync_tests_for_agent($agent_data)) {
+        personalize_agent_set_status($agent_data->machine_name, $next_status);
+        // Unset the started property which will have been changed during
+        // status update and we don't want it getting clobbered by other
+        // saves of the agent.
+        unset($agent_data->started);
+        return TRUE;
+      }
+      else {
+        drupal_set_message(t('There was a problem syncing your personalization components to Lift and it cannot be started at this time.'), 'error');
+        return FALSE;
+      }
+    }
+    catch (Exception $e) {
+      return FALSE;
+    }
+  }
+  else {
+    return personalize_agent_set_status($agent_data->machine_name, $next_status);
+  }
+}
 
 /**
  * Sets up a multivariate test as defined by the variation sets created.

--- a/acquia_lift.admin.wizard.inc
+++ b/acquia_lift.admin.wizard.inc
@@ -15,13 +15,6 @@
  * Alter hook for the process bar on the campaign wizard form.
  */
 function acquia_lift_personalize_campaign_wizard_process_bar_alter(&$form, &$form_state, $form_id) {
-  $agent = $form['#agent'];
-  module_load_include('inc', 'acquia_lift', 'acquia_lift.admin');
-  if (!acquia_lift_target_definition_changes_allowed($agent)) {
-    unset($form['process_bar']['actions']);
-    $form['actions']['submit']['#disabled'] = TRUE;
-    return;
-  }
   // For each status form, handle the status change along with any
   // nested agent implementations.
   foreach (element_children($form['process_bar']['actions']['status']['status_wrapper']) as $form_element) {
@@ -38,45 +31,11 @@ function acquia_lift_personalize_campaign_wizard_base_alter(&$form, &$form_state
   if (acquia_lift_target_definition_changes_allowed($agent)) {
     // Make the campaign name a self-revealing text input.
     $form['agent_basic_info']['title']['#theme_wrappers'][] = 'acquia_lift_revealing_input';
-    return;
   }
-  // Give instructions for how to make the campaign editable.
-  $form['agent_basic_info']['title']['#disabled'] = TRUE;
-  $status = personalize_agent_get_status($agent->machine_name);
-  switch ($status) {
-    case PERSONALIZE_STATUS_RUNNING:
-      $message = t('Personalizations that are running cannot be edited. Click "Pause" to allow it to be edited. Personalizations that are paused display the default variations to visitors.');
-      $button_text = t("Pause");
-      $next_status = PERSONALIZE_STATUS_PAUSED;
-      break;
-    case PERSONALIZE_STATUS_SCHEDULED:
-      $message = t('Personalizations with scheduled start dates cannot be edited.  Click "Make editable" to allow it to be edited. After you have made your changes, go to the Review section to restart the personalization.');
-      $button_text = t('Make editable');
-      $next_status = empty($agent->started) ? PERSONALIZE_STATUS_NOT_STARTED : PERSONALIZE_STATUS_PAUSED;
-      break;
-    case PERSONALIZE_STATUS_COMPLETED:
-      $message = t('Archived personalizations cannot be edited.  Click "Unarchive" for the personalization to restore it to a Paused status, allowing it to be edited.');
-      $button_text = t('Unarchive');
-      $next_status = PERSONALIZE_STATUS_PAUSED;
-      break;
-    default:
-      // Should not get here.
-      return;
+  else {
+    // Give instructions for how to make the campaign editable.
+    $form['agent_basic_info']['title']['#disabled'] = TRUE;
   }
-  drupal_set_message($message, 'warning');
-  $form['agent_basic_info']['status_submit'] = array(
-    '#type' => 'submit',
-    '#value' => $button_text,
-    '#personalize_next_status' => $next_status,
-    '#submit' => array('acquia_lift_personalize_campaign_wizard_submit_editable'),
-    '#limit_valiation_errors' => array('agent_basic_info'),
-    '#attributes' => array(
-      'class' => array(
-        'acquia-lift-submit-button',
-        'action-item-primary-active'
-      ),
-    ),
-  );
 }
 
 /**

--- a/acquia_lift.admin.wizard.inc
+++ b/acquia_lift.admin.wizard.inc
@@ -22,34 +22,6 @@ function acquia_lift_personalize_campaign_wizard_process_bar_alter(&$form, &$for
     $form['actions']['submit']['#disabled'] = TRUE;
     return;
   }
-  $nested = acquia_lift_get_nested_tests($agent);
-  if (empty($nested)) {
-    return;
-  }
-  // If we're editing an existing agent, add a "Reset data" button next to
-  // the Pause/Resume button.
-  // @todo Move this to the reports page.
-  $reset_form = array(
-    '#prefix' => '<div id="personalize-acquia-lift-reset-form">',
-    '#suffix' => '</div>'
-  );
-  $reset_form['actions']['reset'] = array(
-    '#prefix' => '<div id="personalize-acquia-lift-reset">',
-    '#suffix' => '</div>',
-    '#type' => 'submit',
-    '#name' => 'reset_submit',
-    '#value' => t('Reset data'),
-    '#attributes' => array(
-      'class' => array('action-item-primary-active'),
-    ),
-    '#ajax' => array(
-      'callback' => 'personalize_acquia_lift_ajax_callback',
-      'wrapper' => 'personalize-acquia-lift-reset-form',
-      'effect' => 'fade',
-    )
-  );
-  $reset_form['actions']['reset']['#submit'] = array('acquia_lift_reset_submit');
-  $form['process_bar']['actions']['reset_lift_agent'] = $reset_form;
 }
 
 /**

--- a/acquia_lift.admin.wizard.inc
+++ b/acquia_lift.admin.wizard.inc
@@ -22,6 +22,11 @@ function acquia_lift_personalize_campaign_wizard_process_bar_alter(&$form, &$for
     $form['actions']['submit']['#disabled'] = TRUE;
     return;
   }
+  // For each status form, handle the status change along with any
+  // nested agent implementations.
+  foreach (element_children($form['process_bar']['actions']['status']['status_wrapper']) as $form_element) {
+    $form['process_bar']['actions']['status']['status_wrapper'][$form_element]['#submit'] = array('acquia_lift_personalize_campaign_wizard_status_submit');
+  }
 }
 
 /**
@@ -1395,6 +1400,18 @@ function acquia_lift_personalize_campaign_wizard_review_submit(&$form, &$form_st
   // If we got here, some sort of error occurred so make sure we don't move to
   // the next step.
   $form_state['redirect'] = current_path();
+}
+
+/**
+ * Submit function for the status change buttons.
+ */
+function acquia_lift_personalize_campaign_wizard_status_submit($form, &$form_state) {
+  $next_status = $form_state['triggering_element']['#personalize_next_status'];
+  $agent_data = personalize_agent_load($form_state['values']['agent_name']);
+  module_load_include('inc', 'acquia_lift', 'acquia_lift.admin');
+  if (!acquia_lift_target_set_status($agent_data, $next_status)) {
+    form_set_error(NULL, t('There was a problem implementing the personalization as defined.'));
+  }
 }
 
 /**

--- a/acquia_lift.admin.wizard.inc
+++ b/acquia_lift.admin.wizard.inc
@@ -1387,30 +1387,9 @@ function acquia_lift_personalize_campaign_wizard_review_submit(&$form, &$form_st
   // the campaign.
   if (isset($form_state['triggering_element']['#personalize_next_status'])) {
     $next_status = $form_state['triggering_element']['#personalize_next_status'];
-    if ($next_status == PERSONALIZE_STATUS_RUNNING || $next_status == PERSONALIZE_STATUS_SCHEDULED) {
-      module_load_include('inc', 'acquia_lift', 'acquia_lift.admin');
-      module_load_include('inc', 'acquia_lift', 'acquia_lift.batch');
-      try {
-        $agent_data->tests_to_delete = acquia_lift_implement_test_structure($agent_data);
-        if (acquia_lift_batch_sync_tests_for_agent($agent_data)) {
-          personalize_agent_set_status($agent_data->machine_name, $next_status);
-          // Unset the started property which will have been changed during
-          // status update and we don't want it getting clobbered by other
-          // saves of the agent.
-          unset($agent_data->started);
-          return;
-        }
-        else {
-          drupal_set_message(t('There was a problem syncing your personalization components to Lift and it cannot be started at this time.'), 'error');
-        }
-      }
-      catch (Exception $e) {
-        form_set_error(NULL, t('There was a problem implementing the personalization as defined.'));
-      }
-    }
-    else {
-      personalize_agent_set_status($agent_data->machine_name, $next_status);
-      return;
+    module_load_include('inc', 'acquia_lift', 'acquia_lift.admin');
+    if (!acquia_lift_target_set_status($agent_data, $next_status)) {
+      form_set_error(NULL, t('There was a problem implementing the personalization as defined.'));
     }
   }
   // If we got here, some sort of error occurred so make sure we don't move to

--- a/acquia_lift.module
+++ b/acquia_lift.module
@@ -153,6 +153,13 @@ function acquia_lift_menu() {
     'type' => MENU_CALLBACK,
     'file' => 'acquia_lift.admin.wizard.inc',
   );
+  $items['admin/structure/personalize/manage/%personalize_agent/reset'] = array(
+    'page callback' => 'acquia_lift_reset_nested_agents',
+    'page arguments' => array(4),
+    'access callback' =>'acquia_lift_target_access',
+    'access arguments' => array(4),
+    'type' => MENU_CALLBACK,
+  );
   // Page callback for the list of legacy agents.
   $items['admin/structure/personalize/legacy'] = array(
     'title' => 'Legacy Campaigns',
@@ -1110,6 +1117,7 @@ function acquia_lift_library() {
     'version' => VERSION,
     'js' => array(
       $path . '/js/acquia_lift_target.admin.js' => array(),
+      $path . '/js/acquia_lift.admin.js' => array(),
     ),
     'css' => array(
       $path . '/css/acquia_lift.admin.css',
@@ -2199,37 +2207,67 @@ function acquia_lift_form_personalize_status_change_form_alter(&$form, &$form_st
 }
 
 /**
- * Ajax callback for the "Reset data" button.
+ *  Implements hook_personalize_campaign_action_links_alter().
  */
-function personalize_acquia_lift_ajax_callback($form, $form_state) {
-  return $form['agent_form']['agent_fieldset']['header']['reset_lift_agent'];
+function acquia_lift_personalize_campaign_action_links_alter(&$links, $agent_data, $destination) {
+  // If this agent has nested test agents, then provide a link to reset data.
+  $nested = acquia_lift_get_nested_tests($agent_data);
+  if (empty($nested)) {
+    return;
+  }
+  $links[] = array(
+    'title' => t('Reset data'),
+    'href' => 'admin/structure/personalize/manage/' . $agent_data->machine_name . '/reset',
+    'query' => array(
+      'destination' => $destination,
+    ),
+    'attributes' => array(
+      'class' => array('acquia-lift-reset'),
+    ),
+  );
 }
 
-
 /**
- * Submit callback for the "Reset data" button.
+ * Reset the data for a particular agent and redirect to the agent details.
+ *
+ * @param stdClass $parent_agent
+ *   The agent data for the parent agent to reset.
  */
-function acquia_lift_reset_submit($form, $form_state) {
-  $agent_name = $form_state['values']['agent'];
-  if ($parent_agent = personalize_agent_load($agent_name)) {
-    $nested_tests = acquia_lift_get_nested_tests($parent_agent);
-    foreach ($nested_tests as $name) {
-      acquia_lift_reset_agent($name);
-    }
+function acquia_lift_reset_nested_agents($parent_agent) {
+  $show_success = TRUE;
+  $nested_tests = acquia_lift_get_nested_tests($parent_agent);
+  foreach ($nested_tests as $name) {
+    if (!acquia_lift_reset_agent($name)) {
+      $show_success = FALSE;
+    };
   }
+  if ($show_success) {
+    drupal_set_message(t('The data has been reset for all tests within %campaign.', array(
+        '%campaign' => $parent_agent->label,
+    )));
+  }
+  drupal_goto('admin/structure/personalize/manage/' . $parent_agent->machine_name . '/review');
 }
 
 /**
  * Resets the data for the specified agent.
+ *
+ * @param string $agent_name
+ *   The name of the agent to reset
+ * @return bool
+ *   True if reset, false if exception thrown.
  */
 function acquia_lift_reset_agent($agent_name) {
+  $success = TRUE;
   try {
     $api = AcquiaLiftAPI::getInstance(variable_get('acquia_lift_account_info', array()));
     $api->resetAgentData($agent_name);
   }
   catch (Exception $e) {
+    $success = FALSE;
     drupal_set_message(t('The data for the specified agent could not be reset'), 'error');
   }
+  return $success;
 }
 
 /**

--- a/acquia_lift.module
+++ b/acquia_lift.module
@@ -180,11 +180,6 @@ function acquia_lift_menu_alter(&$items) {
   // access to Lift campaigns.
   $items['admin/structure/personalize/manage/%personalize_agent/edit']['access callback'] = 'acquia_lift_campaign_edit_access';
   $items['admin/structure/personalize/manage/%personalize_agent/edit']['access arguments'] = array(4);
-
-  // Updates to the callback for changing a campaign's status.
-  $items['admin/structure/personalize/manage/%personalize_agent/status/%']['page callback'] = 'acquia_lift_target_status_callback';
-  $items['admin/structure/personalize/manage/%personalize_agent/status/%']['file'] = 'acquia_lift.admin.inc';
-  $items['admin/structure/personalize/manage/%personalize_agent/status/%']['module'] = 'acquia_lift';
 }
 
 /**

--- a/acquia_lift.module
+++ b/acquia_lift.module
@@ -180,6 +180,11 @@ function acquia_lift_menu_alter(&$items) {
   // access to Lift campaigns.
   $items['admin/structure/personalize/manage/%personalize_agent/edit']['access callback'] = 'acquia_lift_campaign_edit_access';
   $items['admin/structure/personalize/manage/%personalize_agent/edit']['access arguments'] = array(4);
+
+  // Updates to the callback for changing a campaign's status.
+  $items['admin/structure/personalize/manage/%personalize_agent/status/%']['page callback'] = 'acquia_lift_target_status_callback';
+  $items['admin/structure/personalize/manage/%personalize_agent/status/%']['file'] = 'acquia_lift.admin.inc';
+  $items['admin/structure/personalize/manage/%personalize_agent/status/%']['module'] = 'acquia_lift';
 }
 
 /**

--- a/acquia_lift.module
+++ b/acquia_lift.module
@@ -2210,21 +2210,59 @@ function acquia_lift_form_personalize_status_change_form_alter(&$form, &$form_st
  *  Implements hook_personalize_campaign_action_links_alter().
  */
 function acquia_lift_personalize_campaign_action_links_alter(&$links, $agent_data, $destination) {
-  // If this agent has nested test agents, then provide a link to reset data.
-  $nested = acquia_lift_get_nested_tests($agent_data);
-  if (empty($nested)) {
-    return;
+  module_load_include('inc', 'acquia_lift', 'acquia_lift.admin');
+  if (acquia_lift_target_definition_changes_allowed($agent_data)) {
+    // If this agent has nested test agents, then provide a link to reset data.
+    $nested = acquia_lift_get_nested_tests($agent_data);
+    if (empty($nested)) {
+      return;
+    }
+    $links[] = array(
+      'title' => t('Reset data'),
+      'href' => 'admin/structure/personalize/manage/' . $agent_data->machine_name . '/reset',
+      'query' => array(
+        'destination' => $destination,
+      ),
+      'attributes' => array(
+        'class' => array('acquia-lift-reset'),
+      ),
+    );
   }
-  $links[] = array(
-    'title' => t('Reset data'),
-    'href' => 'admin/structure/personalize/manage/' . $agent_data->machine_name . '/reset',
-    'query' => array(
-      'destination' => $destination,
-    ),
-    'attributes' => array(
-      'class' => array('acquia-lift-reset'),
-    ),
-  );
+  else {
+    // If no changes are allowed, then don't provide any actions except an
+    // action to 'pause' the campaign.
+    $status = personalize_agent_get_status($agent_data->machine_name);
+    switch ($status) {
+      case PERSONALIZE_STATUS_RUNNING:
+        $message = t('Personalizations that are running cannot be edited. Click "Pause" to allow it to be edited. Personalizations that are paused display the default variations to visitors.');
+        $button_text = t("Pause");
+        $next_status = PERSONALIZE_STATUS_PAUSED;
+        break;
+      case PERSONALIZE_STATUS_SCHEDULED:
+        $message = t('Personalizations with scheduled start dates cannot be edited.  Click "Make editable" to allow it to be edited. After you have made your changes, go to the Review section to restart the personalization.');
+        $button_text = t('Make editable');
+        $next_status = empty($agent_data->started) ? PERSONALIZE_STATUS_NOT_STARTED : PERSONALIZE_STATUS_PAUSED;
+        break;
+      case PERSONALIZE_STATUS_COMPLETED:
+        $message = t('Archived personalizations cannot be edited.  Click "Unarchive" for the personalization to restore it to a Paused status, allowing it to be edited.');
+        $button_text = t('Unarchive');
+        $next_status = PERSONALIZE_STATUS_PAUSED;
+        break;
+      default:
+        // Should not get here.
+        return;
+    }
+    drupal_set_message($message, 'warning');
+    $links = array(
+      array(
+        'title' => $button_text,
+        'href' => '#',
+        'attributes' => array(
+          'data-personalize-action' => 'personalize-wizard-status-' . $next_status,
+        ),
+      ),
+    );
+  }
 }
 
 /**

--- a/js/acquia_lift.admin.js
+++ b/js/acquia_lift.admin.js
@@ -47,14 +47,12 @@
   Drupal.behaviors.acquiaLiftCampaignEdit = {
     attach: function (context, settings) {
       // Add a handler to the "Reset data" button to warn the user before resetting the data.
-      $('#personalize-acquia-lift-reset input[type="submit"]').once('acquia-lift-reset').each(function() {
-        // Overwrite beforeSubmit of the ajax event.
-        Drupal.ajax[this.id].options.beforeSubmit = function(form_values, $element, options) {
-          if (confirm(Drupal.t('This action will delete all existing data for this personalization and cannot be undone. Are you sure you want to continue?'))) {
-            return true;
-          } else {
-            return false;
-          }
+      $('.personalize-wizard-process-bar-actions .acquia-lift-reset').once('acquia-lift-reset').click(function(e) {
+        if (confirm(Drupal.t('This action will delete all existing data for this personalization and cannot be undone. Are you sure you want to continue?'))) {
+          return true;
+        } else {
+          e.stopImmediatePropagation();
+          return false;
         }
       });
     }

--- a/tests/acquia_lift.test
+++ b/tests/acquia_lift.test
@@ -2873,8 +2873,80 @@ class AcquiaLiftWebTestCampaignWizard extends AcquiaLiftWebTestBase {
     );
     $this->drupalPost(NULL, $edit, $this->getButton('wizard_save'));
 
-    // Start the campaign from the review screen.
+    // Schedule the campaign to start in the future.
+    $this->drupalGet("admin/structure/personalize/manage/$machine_name/scheduling");
+    $start_date = strtotime('+1 month midnight');
+
+    $edit = array(
+      'campaign_start' => 'specified',
+      'campaign_start_date[month]' => intval(date('m', $start_date)),
+      'campaign_start_date[day]' => date('d', $start_date),
+      'campaign_start_date[year]' => date('Y', $start_date),
+    );
+    $this->drupalPost(NULL, $edit, $this->getButton('wizard_next'));
+
+    // Verify options.
+    $this->drupalGet("admin/structure/personalize/manage/$machine_name/variations");
+    $this->assertNoText($message_running);
+    $this->assertNoText($message_scheduled);
+    $this->assertNoText($message_completed);
+    $this->assertFieldById('edit-save');
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
+    $this->drupalGet("admin/structure/personalize/manage/$machine_name/goals");
+    $this->assertNoText($message_running);
+    $this->assertNoText($message_scheduled);
+    $this->assertNoText($message_completed);
+    $this->assertFieldById('edit-save');
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
+    $this->drupalGet("admin/structure/personalize/manage/$machine_name/targeting");
+    $this->assertNoText($message_running);
+    $this->assertNoText($message_scheduled);
+    $this->assertNoText($message_completed);
+    $this->assertFieldById('edit-save');
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
+    $this->drupalGet("admin/structure/personalize/manage/$machine_name/scheduling");
+    $this->assertNoText($message_running);
+    $this->assertNoText($message_scheduled);
+    $this->assertNoText($message_completed);
+    $this->assertFieldById('edit-save');
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
     $this->drupalGet("admin/structure/personalize/manage/$machine_name/review");
+    $this->assertNoText($message_running);
+    $this->assertNoText($message_scheduled);
+    $this->assertNoText($message_completed);
+    $this->assertFieldById('edit-save');
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
+
+    // Remove the scheduled date prior to starting the campaign.
+    $this->drupalGet("admin/structure/personalize/manage/$machine_name/scheduling");
+
+    $edit = array(
+      'campaign_start' => 'none',
+    );
+    $this->drupalPost(NULL, $edit, $this->getButton('wizard_next'));
+
+    // Verify options and start the campaign from the review screen.
+    $this->drupalGet("admin/structure/personalize/manage/$machine_name/review");
+    $this->assertFieldById('edit-save');
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
     $this->drupalPost(NULL, array(), $this->getButton('wizard_start'));
 
     // Verify that the correct messaging is shown on all campaign wizard pages.
@@ -2882,22 +2954,47 @@ class AcquiaLiftWebTestCampaignWizard extends AcquiaLiftWebTestBase {
     $this->assertText($message_running);
     $this->assertNoText($message_scheduled);
     $this->assertNoText($message_completed);
+    $this->assertNoFieldById('edit-save');
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
     $this->drupalGet("admin/structure/personalize/manage/$machine_name/goals");
     $this->assertText($message_running);
     $this->assertNoText($message_scheduled);
     $this->assertNoText($message_completed);
+    $this->assertNoFieldById('edit-save');
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
     $this->drupalGet("admin/structure/personalize/manage/$machine_name/targeting");
     $this->assertText($message_running);
     $this->assertNoText($message_scheduled);
     $this->assertNoText($message_completed);
+    $this->assertNoFieldById('edit-save');
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
     $this->drupalGet("admin/structure/personalize/manage/$machine_name/scheduling");
     $this->assertText($message_running);
     $this->assertNoText($message_scheduled);
     $this->assertNoText($message_completed);
+    $this->assertNoFieldById('edit-save');
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
     $this->drupalGet("admin/structure/personalize/manage/$machine_name/review");
     $this->assertText($message_running);
     $this->assertNoText($message_scheduled);
     $this->assertNoText($message_completed);
+    $this->assertNoFieldById('edit-save');
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
 
     // Pause the campaign and verify that messaging is removed.
     $this->drupalPost(NULL, array(), t('Pause'));
@@ -2905,22 +3002,47 @@ class AcquiaLiftWebTestCampaignWizard extends AcquiaLiftWebTestBase {
     $this->assertNoText($message_running);
     $this->assertNoText($message_scheduled);
     $this->assertNoText($message_completed);
+    $this->assertFieldById('edit-save');
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
     $this->drupalGet("admin/structure/personalize/manage/$machine_name/goals");
     $this->assertNoText($message_running);
     $this->assertNoText($message_scheduled);
     $this->assertNoText($message_completed);
+    $this->assertFieldById('edit-save');
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
     $this->drupalGet("admin/structure/personalize/manage/$machine_name/targeting");
     $this->assertNoText($message_running);
     $this->assertNoText($message_scheduled);
     $this->assertNoText($message_completed);
+    $this->assertFieldById('edit-save');
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
     $this->drupalGet("admin/structure/personalize/manage/$machine_name/scheduling");
     $this->assertNoText($message_running);
     $this->assertNoText($message_scheduled);
     $this->assertNoText($message_completed);
+    $this->assertFieldById('edit-save');
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
     $this->drupalGet("admin/structure/personalize/manage/$machine_name/review");
     $this->assertNoText($message_running);
     $this->assertNoText($message_scheduled);
     $this->assertNoText($message_completed);
+    $this->assertFieldById('edit-save');
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
 
     // Schedule the campaign to start in the future.
     $this->drupalGet("admin/structure/personalize/manage/$machine_name/scheduling");
@@ -2933,6 +3055,55 @@ class AcquiaLiftWebTestCampaignWizard extends AcquiaLiftWebTestBase {
       'campaign_start_date[year]' => date('Y', $start_date),
     );
     $this->drupalPost(NULL, $edit, $this->getButton('wizard_next'));
+
+    // Verify that the correct messaging is shown on all campaign wizard pages.
+    $this->drupalGet("admin/structure/personalize/manage/$machine_name/variations");
+    $this->assertNoText($message_running);
+    $this->assertNoText($message_scheduled);
+    $this->assertNoText($message_completed);
+    $this->assertFieldById('edit-save');
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
+    $this->drupalGet("admin/structure/personalize/manage/$machine_name/goals");
+    $this->assertNoText($message_running);
+    $this->assertNoText($message_scheduled);
+    $this->assertNoText($message_completed);
+    $this->assertFieldById('edit-save');
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
+    $this->drupalGet("admin/structure/personalize/manage/$machine_name/targeting");
+    $this->assertNoText($message_running);
+    $this->assertNoText($message_scheduled);
+    $this->assertNoText($message_completed);
+    $this->assertFieldById('edit-save');
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
+    $this->drupalGet("admin/structure/personalize/manage/$machine_name/scheduling");
+    $this->assertNoText($message_running);
+    $this->assertNoText($message_scheduled);
+    $this->assertNoText($message_completed);
+    $this->assertFieldById('edit-save');
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
+    $this->drupalGet("admin/structure/personalize/manage/$machine_name/review");
+    $this->assertNoText($message_running);
+    $this->assertNoText($message_scheduled);
+    $this->assertNoText($message_completed);
+    $this->assertFieldById('edit-save');
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
+
+    // Actually schedule the campaign.
     module_load_include('inc', 'personalize', 'personalize.admin.campaign');
     $button_text = t('Start on @start_date', array(
       '@start_date' => _personalize_campaign_wizard_date($start_date),
@@ -2944,22 +3115,47 @@ class AcquiaLiftWebTestCampaignWizard extends AcquiaLiftWebTestBase {
     $this->assertNoText($message_running);
     $this->assertText($message_scheduled);
     $this->assertNoText($message_completed);
+    $this->assertNoFieldById('edit-save');
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
     $this->drupalGet("admin/structure/personalize/manage/$machine_name/goals");
     $this->assertNoText($message_running);
     $this->assertText($message_scheduled);
     $this->assertNoText($message_completed);
+    $this->assertNoFieldById('edit-save');
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
     $this->drupalGet("admin/structure/personalize/manage/$machine_name/targeting");
     $this->assertNoText($message_running);
     $this->assertText($message_scheduled);
     $this->assertNoText($message_completed);
+    $this->assertNoFieldById('edit-save');
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
     $this->drupalGet("admin/structure/personalize/manage/$machine_name/scheduling");
     $this->assertNoText($message_running);
     $this->assertText($message_scheduled);
     $this->assertNoText($message_completed);
+    $this->assertNoFieldById('edit-save');
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
     $this->drupalGet("admin/structure/personalize/manage/$machine_name/review");
     $this->assertNoText($message_running);
     $this->assertText($message_scheduled);
     $this->assertNoText($message_completed);
+    $this->assertNoFieldById('edit-save');
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
 
     // Complete the campaign and verify messaging.
     personalize_agent_set_status($machine_name, PERSONALIZE_STATUS_COMPLETED);
@@ -2968,22 +3164,46 @@ class AcquiaLiftWebTestCampaignWizard extends AcquiaLiftWebTestBase {
     $this->assertNoText($message_running);
     $this->assertNoText($message_scheduled);
     $this->assertText($message_completed);
+    $this->assertNoFieldById('edit-save');
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
     $this->drupalGet("admin/structure/personalize/manage/$machine_name/goals");
     $this->assertNoText($message_running);
     $this->assertNoText($message_scheduled);
     $this->assertText($message_completed);
+    $this->assertNoFieldById('edit-save');
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
     $this->drupalGet("admin/structure/personalize/manage/$machine_name/targeting");
     $this->assertNoText($message_running);
     $this->assertNoText($message_scheduled);
     $this->assertText($message_completed);
+    $this->assertNoFieldById('edit-save');
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
     $this->drupalGet("admin/structure/personalize/manage/$machine_name/scheduling");
     $this->assertNoText($message_running);
     $this->assertNoText($message_scheduled);
     $this->assertText($message_completed);
+    $this->assertNoFieldById('edit-save');
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
     $this->drupalGet("admin/structure/personalize/manage/$machine_name/review");
     $this->assertNoText($message_running);
     $this->assertNoText($message_scheduled);
     $this->assertText($message_completed);
+    $this->assertNoFieldById('edit-save');
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
   }
-
 }

--- a/tests/acquia_lift.test
+++ b/tests/acquia_lift.test
@@ -1648,16 +1648,17 @@ class AcquiaLiftWebTestTarget extends AcquiaLiftWebTestBase {
 
   function testNestedAgentsButtons() {
     $this->drupalLogin($this->managerUser);
-    $reset_button_name = 'reset_submit';
     $targeting_agent_no_nesting = $this->createTargetingAgent();
-    $this->drupalGet('admin/structure/personalize/manage/' . $targeting_agent_no_nesting->machine_name . '/edit');
+    $this->drupalGet('admin/structure/personalize/manage/' . $targeting_agent_no_nesting->machine_name . '/variations');
     // There are no nested tests so there shouldn't be any buttons relating to
     // test agents.
-    $this->assertNoFieldByName($reset_button_name);
+    $reset_link = 'admin/structure/personalize/manage/' . $targeting_agent_no_nesting->machine_name . '/reset';
+    $this->assertNoLinkByHref($reset_link);
     $agent_with_nesting = $this->createTargetingAgentWithNestedTest();
-    $this->drupalGet('admin/structure/personalize/manage/' . $agent_with_nesting->machine_name . '/edit');
+    $this->drupalGet('admin/structure/personalize/manage/' . $agent_with_nesting->machine_name . '/variations');
     // This campaign has a nested test so those buttons should be visible.
-    $this->assertFieldByName($reset_button_name);
+    $reset_link = 'admin/structure/personalize/manage/' . $agent_with_nesting->machine_name . '/reset';
+    $this->assertLinkByHref($reset_link);
   }
 
   function testNestedAgentStatus() {

--- a/tests/acquia_lift.test
+++ b/tests/acquia_lift.test
@@ -2859,6 +2859,14 @@ class AcquiaLiftWebTestCampaignWizard extends AcquiaLiftWebTestBase {
     $agent = $this->createTargetingAgent();
     $machine_name = $agent->machine_name;
 
+    $campaign_pages = array(
+      "admin/structure/personalize/manage/$machine_name/variations",
+      "admin/structure/personalize/manage/$machine_name/goals",
+      "admin/structure/personalize/manage/$machine_name/targeting",
+      "admin/structure/personalize/manage/$machine_name/scheduling",
+      "admin/structure/personalize/manage/$machine_name/review",
+    );
+
     // Add option set.
     $this->createPersonalizedBlock(0, $agent);
 
@@ -2886,51 +2894,17 @@ class AcquiaLiftWebTestCampaignWizard extends AcquiaLiftWebTestBase {
     $this->drupalPost(NULL, $edit, $this->getButton('wizard_next'));
 
     // Verify options.
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/variations");
-    $this->assertNoText($message_running);
-    $this->assertNoText($message_scheduled);
-    $this->assertNoText($message_completed);
-    $this->assertFieldById('edit-save');
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/goals");
-    $this->assertNoText($message_running);
-    $this->assertNoText($message_scheduled);
-    $this->assertNoText($message_completed);
-    $this->assertFieldById('edit-save');
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/targeting");
-    $this->assertNoText($message_running);
-    $this->assertNoText($message_scheduled);
-    $this->assertNoText($message_completed);
-    $this->assertFieldById('edit-save');
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/scheduling");
-    $this->assertNoText($message_running);
-    $this->assertNoText($message_scheduled);
-    $this->assertNoText($message_completed);
-    $this->assertFieldById('edit-save');
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/review");
-    $this->assertNoText($message_running);
-    $this->assertNoText($message_scheduled);
-    $this->assertNoText($message_completed);
-    $this->assertFieldById('edit-save');
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
+    foreach ($campaign_pages as $page) {
+      $this->drupalGet($page);
+      $this->assertNoText($message_running);
+      $this->assertNoText($message_scheduled);
+      $this->assertNoText($message_completed);
+      $this->assertFieldById('edit-save');
+      $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+      $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+      $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+      $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
+    }
 
     // Remove the scheduled date prior to starting the campaign.
     $this->drupalGet("admin/structure/personalize/manage/$machine_name/scheduling");
@@ -2940,109 +2914,49 @@ class AcquiaLiftWebTestCampaignWizard extends AcquiaLiftWebTestBase {
     );
     $this->drupalPost(NULL, $edit, $this->getButton('wizard_next'));
 
-    // Verify options and start the campaign from the review screen.
+    // Verify options.
+    foreach ($campaign_pages as $page) {
+      $this->drupalGet($page);
+      $this->assertNoText($message_running);
+      $this->assertNoText($message_scheduled);
+      $this->assertNoText($message_completed);
+      $this->assertFieldById('edit-save');
+      $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+      $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+      $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+      $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
+    }
+
+    // Start the campaign.
     $this->drupalGet("admin/structure/personalize/manage/$machine_name/review");
-    $this->assertFieldById('edit-save');
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
     $this->drupalPost(NULL, array(), $this->getButton('wizard_start'));
 
     // Verify that the correct messaging is shown on all campaign wizard pages.
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/variations");
-    $this->assertText($message_running);
-    $this->assertNoText($message_scheduled);
-    $this->assertNoText($message_completed);
-    $this->assertNoFieldById('edit-save');
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/goals");
-    $this->assertText($message_running);
-    $this->assertNoText($message_scheduled);
-    $this->assertNoText($message_completed);
-    $this->assertNoFieldById('edit-save');
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/targeting");
-    $this->assertText($message_running);
-    $this->assertNoText($message_scheduled);
-    $this->assertNoText($message_completed);
-    $this->assertNoFieldById('edit-save');
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/scheduling");
-    $this->assertText($message_running);
-    $this->assertNoText($message_scheduled);
-    $this->assertNoText($message_completed);
-    $this->assertNoFieldById('edit-save');
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/review");
-    $this->assertText($message_running);
-    $this->assertNoText($message_scheduled);
-    $this->assertNoText($message_completed);
-    $this->assertNoFieldById('edit-save');
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
+    foreach ($campaign_pages as $page) {
+      $this->drupalGet($page);
+      $this->assertText($message_running);
+      $this->assertNoText($message_scheduled);
+      $this->assertNoText($message_completed);
+      $this->assertNoFieldById('edit-save');
+      $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+      $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+      $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+      $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
+    }
 
     // Pause the campaign and verify that messaging is removed.
     $this->drupalPost(NULL, array(), t('Pause'));
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/variations");
-    $this->assertNoText($message_running);
-    $this->assertNoText($message_scheduled);
-    $this->assertNoText($message_completed);
-    $this->assertFieldById('edit-save');
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/goals");
-    $this->assertNoText($message_running);
-    $this->assertNoText($message_scheduled);
-    $this->assertNoText($message_completed);
-    $this->assertFieldById('edit-save');
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/targeting");
-    $this->assertNoText($message_running);
-    $this->assertNoText($message_scheduled);
-    $this->assertNoText($message_completed);
-    $this->assertFieldById('edit-save');
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/scheduling");
-    $this->assertNoText($message_running);
-    $this->assertNoText($message_scheduled);
-    $this->assertNoText($message_completed);
-    $this->assertFieldById('edit-save');
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/review");
-    $this->assertNoText($message_running);
-    $this->assertNoText($message_scheduled);
-    $this->assertNoText($message_completed);
-    $this->assertFieldById('edit-save');
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
+    foreach ($campaign_pages as $page) {
+      $this->drupalGet($page);
+      $this->assertNoText($message_running);
+      $this->assertNoText($message_scheduled);
+      $this->assertNoText($message_completed);
+      $this->assertFieldById('edit-save');
+      $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+      $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+      $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+      $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
+    }
 
     // Schedule the campaign to start in the future.
     $this->drupalGet("admin/structure/personalize/manage/$machine_name/scheduling");
@@ -3057,51 +2971,17 @@ class AcquiaLiftWebTestCampaignWizard extends AcquiaLiftWebTestBase {
     $this->drupalPost(NULL, $edit, $this->getButton('wizard_next'));
 
     // Verify that the correct messaging is shown on all campaign wizard pages.
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/variations");
-    $this->assertNoText($message_running);
-    $this->assertNoText($message_scheduled);
-    $this->assertNoText($message_completed);
-    $this->assertFieldById('edit-save');
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/goals");
-    $this->assertNoText($message_running);
-    $this->assertNoText($message_scheduled);
-    $this->assertNoText($message_completed);
-    $this->assertFieldById('edit-save');
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/targeting");
-    $this->assertNoText($message_running);
-    $this->assertNoText($message_scheduled);
-    $this->assertNoText($message_completed);
-    $this->assertFieldById('edit-save');
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/scheduling");
-    $this->assertNoText($message_running);
-    $this->assertNoText($message_scheduled);
-    $this->assertNoText($message_completed);
-    $this->assertFieldById('edit-save');
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/review");
-    $this->assertNoText($message_running);
-    $this->assertNoText($message_scheduled);
-    $this->assertNoText($message_completed);
-    $this->assertFieldById('edit-save');
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
+    foreach ($campaign_pages as $page) {
+      $this->drupalGet($page);
+      $this->assertNoText($message_running);
+      $this->assertNoText($message_scheduled);
+      $this->assertNoText($message_completed);
+      $this->assertFieldById('edit-save');
+      $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+      $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+      $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+      $this->assertFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
+    }
 
     // Actually schedule the campaign.
     module_load_include('inc', 'personalize', 'personalize.admin.campaign');
@@ -3111,99 +2991,31 @@ class AcquiaLiftWebTestCampaignWizard extends AcquiaLiftWebTestBase {
     $this->drupalPost(NULL, array(), $button_text);
 
     // Verify that the correct messaging is shown on all campaign wizard pages.
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/variations");
-    $this->assertNoText($message_running);
-    $this->assertText($message_scheduled);
-    $this->assertNoText($message_completed);
-    $this->assertNoFieldById('edit-save');
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/goals");
-    $this->assertNoText($message_running);
-    $this->assertText($message_scheduled);
-    $this->assertNoText($message_completed);
-    $this->assertNoFieldById('edit-save');
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/targeting");
-    $this->assertNoText($message_running);
-    $this->assertText($message_scheduled);
-    $this->assertNoText($message_completed);
-    $this->assertNoFieldById('edit-save');
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/scheduling");
-    $this->assertNoText($message_running);
-    $this->assertText($message_scheduled);
-    $this->assertNoText($message_completed);
-    $this->assertNoFieldById('edit-save');
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/review");
-    $this->assertNoText($message_running);
-    $this->assertText($message_scheduled);
-    $this->assertNoText($message_completed);
-    $this->assertNoFieldById('edit-save');
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
+    foreach ($campaign_pages as $page) {
+      $this->drupalGet($page);
+      $this->assertNoText($message_running);
+      $this->assertText($message_scheduled);
+      $this->assertNoText($message_completed);
+      $this->assertNoFieldById('edit-save');
+      $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+      $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+      $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+      $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
+    }
 
     // Complete the campaign and verify messaging.
     personalize_agent_set_status($machine_name, PERSONALIZE_STATUS_COMPLETED);
     $this->resetAll();
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/variations");
-    $this->assertNoText($message_running);
-    $this->assertNoText($message_scheduled);
-    $this->assertText($message_completed);
-    $this->assertNoFieldById('edit-save');
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/goals");
-    $this->assertNoText($message_running);
-    $this->assertNoText($message_scheduled);
-    $this->assertText($message_completed);
-    $this->assertNoFieldById('edit-save');
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/targeting");
-    $this->assertNoText($message_running);
-    $this->assertNoText($message_scheduled);
-    $this->assertText($message_completed);
-    $this->assertNoFieldById('edit-save');
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/scheduling");
-    $this->assertNoText($message_running);
-    $this->assertNoText($message_scheduled);
-    $this->assertText($message_completed);
-    $this->assertNoFieldById('edit-save');
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/review");
-    $this->assertNoText($message_running);
-    $this->assertNoText($message_scheduled);
-    $this->assertText($message_completed);
-    $this->assertNoFieldById('edit-save');
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
-    $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
+    foreach ($campaign_pages as $page) {
+      $this->drupalGet($page);
+      $this->assertNoText($message_running);
+      $this->assertNoText($message_scheduled);
+      $this->assertText($message_completed);
+      $this->assertNoFieldById('edit-save');
+      $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_RUNNING);
+      $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_PAUSED);
+      $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_COMPLETED);
+      $this->assertNoFieldById('edit-submit-' . PERSONALIZE_STATUS_SCHEDULED);
+    }
   }
 }


### PR DESCRIPTION
Moves the reset functionality to be a page callback rather than a form for ease of integration with ctools.
Also makes sure that status buttons called on the campaign page will run the same nested agent implementation functionality that the review button runs.
