### PR TITLE
Ch 2190

### DIFF
--- a/acquia_lift.module
+++ b/acquia_lift.module
@@ -2922,7 +2922,7 @@ function acquia_lift_get_campaign_details() {
 function acquia_lift_personalize_agent_list_alter(&$agents) {
   // If this is a nested agent, it should not be listed.
   foreach ($agents as $agent_name => $agent) {
-    if ($agent->plugin === 'acquia_lift') {
+    if (in_array($agent->plugin, array(ACQUIA_LIFT_TESTING_AGENT_V1, ACQUIA_LIFT_TESTING_AGENT_V2))) {
       unset($agents[$agent_name]);
     }
   }

--- a/acquia_lift.module
+++ b/acquia_lift.module
@@ -710,7 +710,7 @@ function acquia_lift_personalize_option_set_insert($option_set) {
     $field = field_info_field($option_set->data['personalize_fields_field_name']);
     if (!isset($field['settings']['personalize']) ||
       !$field['settings']['personalize']['enabled'] ||
-      isset($field['settings']['personalize']['create_goal']) ||
+      !isset($field['settings']['personalize']['create_goal']) ||
       !$field['settings']['personalize']['create_goal']
       ) {
       return;

--- a/acquia_lift.module
+++ b/acquia_lift.module
@@ -716,6 +716,7 @@ function acquia_lift_personalize_option_set_insert($option_set) {
       return;
     }
   }
+  // @todo Expose this variable in the UI.
   elseif (!variable_get('acquia_lift_auto_goal', TRUE)) {
     return;
   }

--- a/acquia_lift.module
+++ b/acquia_lift.module
@@ -716,6 +716,9 @@ function acquia_lift_personalize_option_set_insert($option_set) {
       return;
     }
   }
+  elseif (!variable_get('acquia_lift_auto_goal', TRUE)) {
+    return;
+  }
 
   // Only create a goal if there are no goals already set up for the agent.
   $goals = personalize_goal_load_by_conditions(array('agent' => $agent->machine_name));

--- a/acquia_lift.module
+++ b/acquia_lift.module
@@ -694,47 +694,54 @@ function acquia_lift_personalize_option_set_save($option_set) {
 
   module_load_include('inc', 'acquia_lift', 'acquia_lift.admin');
   acquia_lift_validate_minimum_targeting($agent, $option_set);
+}
 
-  // Unless this is a fields-based option set, we're done.
-  if ($option_set->plugin !== 'fields') {
+/**
+ * Implements hook_personalize_option_set_insert().
+ */
+function acquia_lift_personalize_option_set_insert($option_set) {
+  $agent = personalize_agent_load($option_set->agent);
+  if (!acquia_lift_is_targeting_agent($agent)) {
     return;
   }
-
-  // For fields-based option sets, we need to do some more set-up, depending on the
-  // field settings.
-  $field = field_info_field($option_set->data['personalize_fields_field_name']);
-  if (!isset($field['settings']['personalize']) || !$field['settings']['personalize']['enabled']) {
-    return;
+  // Create a goal for hte option set. If it's a fields-based option set we first
+  // check whether this is the configured behavior.
+  if ($option_set->plugin == 'fields') {
+    $field = field_info_field($option_set->data['personalize_fields_field_name']);
+    if (!isset($field['settings']['personalize']) ||
+      !$field['settings']['personalize']['enabled'] ||
+      isset($field['settings']['personalize']['create_goal']) ||
+      !$field['settings']['personalize']['create_goal']
+      ) {
+      return;
+    }
   }
 
-  if (isset($option_set->is_new)) {
-    if (isset($field['settings']['personalize']['create_goal']) && $field['settings']['personalize']['create_goal']) {
-      $goals = personalize_goal_load_by_conditions(array('agent' => $agent->machine_name));
-      if (empty($goals)) {
-        $js_id = personalize_stringify_osid($option_set->osid);
-        $plugin = 'link';
-        $action_label = t('Clicks @option_set', array('@option_set' => $option_set->label));
-        $action_name = personalize_generate_machine_name($action_label, 'visitor_actions_machine_name_exists', '_');
-        $pages = empty($field['settings']['personalize']['goal_pages']) ? '' : $field['settings']['personalize']['goal_pages'];
-        $action = array(
-          'label' => $action_label,
-          'machine_name' => $action_name,
-          'plugin' => $plugin,
-          'client_side' => 1,
-          'identifier' => '[data-personalize=' . $js_id . ']',
-          'event' => 'click',
-          'pages' => $pages,
-          'data' => array(),
-          'limited_use' => 1
-        );
-        // Allow the plugin to modify the action before saving.
-        if ($class = ctools_plugin_load_class('visitor_actions', 'actionable_element', $plugin, 'handler')) {
-          $action = call_user_func_array(array($class, 'actionPresave'), array($action));
-        }
-        if (visitor_actions_save_action($action)) {
-          personalize_goal_save($option_set->agent, $action_name, 1);
-        }
-      }
+  // Only create a goal if there are no goals already set up for the agent.
+  $goals = personalize_goal_load_by_conditions(array('agent' => $agent->machine_name));
+  if (empty($goals)) {
+    $js_id = personalize_stringify_osid($option_set->osid);
+    $plugin = 'link';
+    $action_label = t('Clicks @option_set', array('@option_set' => $option_set->label));
+    $action_name = personalize_generate_machine_name($action_label, 'visitor_actions_machine_name_exists', '_');
+    $pages = empty($field['settings']['personalize']['goal_pages']) ? '' : $field['settings']['personalize']['goal_pages'];
+    $action = array(
+      'label' => $action_label,
+      'machine_name' => $action_name,
+      'plugin' => $plugin,
+      'client_side' => 1,
+      'identifier' => '[data-personalize=' . $js_id . ']',
+      'event' => 'click',
+      'pages' => $pages,
+      'data' => array(),
+      'limited_use' => 1
+    );
+    // Allow the plugin to modify the action before saving.
+    if ($class = ctools_plugin_load_class('visitor_actions', 'actionable_element', $plugin, 'handler')) {
+      $action = call_user_func_array(array($class, 'actionPresave'), array($action));
+    }
+    if (visitor_actions_save_action($action)) {
+      personalize_goal_save($option_set->agent, $action_name, 1);
     }
   }
 }

--- a/tests/acquia_lift.test
+++ b/tests/acquia_lift.test
@@ -1188,6 +1188,44 @@ class AcquiaLiftWebTestWorkflow extends AcquiaLiftWebTestBase {
     $this->assertTrue(empty($goals));
   }
 
+  public function testAutoCreateGoal() {
+    $this->drupalLogin($this->adminUser);
+    $agent = $this->createTargetingAgent();
+    $option_set = $this->createPersonalizedBlock(0, $agent, 2);
+    $this->resetAll();
+    $goals = personalize_goal_load_by_conditions(array('agent' => $agent->machine_name));
+    $this->assertEqual(1, count($goals));
+    $goal = reset($goals);
+    $this->assertEqual('clicks_option_set_' . $option_set->osid, $goal->action);
+    $this->assertEqual(1, $goal->value);
+    // Delete the goal and confirm that saving the option set again does not
+    // result in another goal being created.
+    personalize_goal_delete($goal->id);
+    personalize_option_set_save($option_set);
+    $goals = personalize_goal_load_by_conditions(array('agent' => $agent->machine_name), TRUE);
+    $this->assertEqual(0, count($goals));
+
+    // Add an agent and create a goal before creating an option set. No second
+    // goal should be created for the option set.
+    $agent2 = $this->createTargetingAgent();
+    personalize_goal_save($agent2->machine_name, 'user_login', 2);
+    $this->createPersonalizedBlock(1, $agent2, 2);
+    $this->resetAll();
+    $goals = personalize_goal_load_by_conditions(array('agent' => $agent2->machine_name));
+    $this->assertEqual(1, count($goals));
+    $goal = reset($goals);
+    $this->assertEqual('user_login', $goal->action);
+    $this->assertEqual(2, $goal->value);
+
+    // Now set the variable that prevents auto-creation of goals.
+    variable_set('acquia_lift_auto_goal', FALSE);
+    $agent3 = $this->createTargetingAgent();
+    $this->createPersonalizedBlock(2, $agent3, 2);
+    $this->resetAll();
+    $goals = personalize_goal_load_by_conditions(array('agent' => $agent3->machine_name), TRUE);
+    $this->assertEqual(0, count($goals));
+  }
+
   /**
    * Tests campaign javascript settings.
    */


### PR DESCRIPTION
Moves the logic for automatically creating a "clicks the option set" goal into acquia_lift_personalize_option_set_insert because it only applies to newly created option sets. Continues to respect the setting for fields and provides a variable that can be set to FALSE to prevent the automatic goal creation for non-fields option sets.
