### PR TITLE
Audiences fixes: Address three audience bugs as well as general findings

### DIFF
--- a/acquia_lift.admin.wizard.inc
+++ b/acquia_lift.admin.wizard.inc
@@ -917,7 +917,9 @@ function acquia_lift_personalize_campaign_wizard_goals_ajax_all($form, &$form_st
  */
 function acquia_lift_personalize_campaign_wizard_targeting_add($form, &$form_state) {
   // Increment the number of contexts to be rendered.
-  $context_key = $form_state['triggering_element']['#array_parents'][2];
+  $parents = $form_state['triggering_element']['#parents'];
+  $context_key_pos = array_search('audiences', $parents) + 1;
+  $context_key = $parents[$context_key_pos];
   watchdog('debug', 'adding context to ' . $context_key);
   $form_state['num_contexts_audience'][$context_key]++;
   $form_state['rebuild'] = TRUE;
@@ -943,9 +945,9 @@ function acquia_lift_personalize_campaign_wizard_targeting_remove($form, &$form_
 function acquia_lift_personalize_campaign_wizard_targeting_ajax($form, &$form_state) {
   // Don't show any messages within the AJAX returned.
   drupal_get_messages();
-  watchdog('debug', 'parents: <pre>' . print_r($form_state['triggering_element']['#parents'], TRUE) . '</pre>');
-  watchdog('debug', 'search for audiences: ' . (array_search('audiences',$form_state['triggering_element']['#parents']) + 1));
-  $context_key = $form_state['triggering_element']['#array_parents'][2];
+  $parents = $form_state['triggering_element']['#parents'];
+  $context_key_pos = array_search('audiences', $parents) + 1;
+  $context_key = $parents[$context_key_pos];
   watchdog('debug', 'returning context ' . $context_key);
   return $form['targeting']['audiences'][$context_key]['details']['mapping']['contexts'];
 }
@@ -1067,6 +1069,11 @@ function acquia_lift_personalize_campaign_wizard_goals_validate(&$form, &$form_s
  * Validation function for targeting form.
  */
 function acquia_lift_personalize_campaign_wizard_targeting_validate(&$form, &$form_state) {
+  // Allow advanced AJAX functions such as add/remove contexts to skip
+  // validation and still operate on the full form value set.
+  if (!empty($form_state['triggering_element']['#skip_validation'])) {
+    return;
+  }
   // If we are adding - then validate the required audience fields.
   if (in_array('add', $form_state['triggering_element']['#array_parents'])) {
     if (empty($form_state['values']['audiences']['add']['details']['name'])) {
@@ -1874,20 +1881,6 @@ function _acquia_lift_personalize_campaign_wizard_targeting_audience(&$form, &$f
     ))),
   );
 
-  if (isset($form_state['to_remove_audience'])) {
-    watchdog('debug', 'remove audiences: <pre>' . print_r($form_state['to_remove_audience'], TRUE) . '</pre>');
-  }
-  else {
-    watchdog('debug', 'nothing to remove');
-  }
-  if (isset($form_state['num_contexts_audience'])) {
-    watchdog('debug', 'num contexts audiences: <pre>' . print_r($form_state['num_contexts_audience'], TRUE) . '</pre>');
-  }
-  else {
-    watchdog('debug', 'no context number set');
-  }
-
-
   // Load from the existing form if passed first, otherwise, load from audience.
   $mappings = array();
   if (isset($form_state['values']['audiences'][$parent_identifier]['details']['mapping']['contexts'])) {
@@ -1964,12 +1957,14 @@ function _acquia_lift_personalize_campaign_wizard_targeting_audience(&$form, &$f
       '#value' => 'remove_' . $delta,
       '#theme_wrappers' => array('personalize_html_tag'),
       '#access' => count($mappings) > 1,
+      '#name' => 'audiences[' . $parent_identifier . '][details][mapping][contexts][' . $delta . '][remove]',
       '#attributes' => array(
         'class' => array('personalize-delete-context', 'form-submit',),
         'title' => t('Delete this context.'),
         'id' => 'edit-audiences-' . $parent_identifier . '-details-mapping-contexts-' . $delta . '-remove',
       ),
       '#submit' => array('acquia_lift_personalize_campaign_wizard_targeting_remove'),
+      '#skip_validation' => TRUE,
       '#ajax' => array(
         'callback' => 'acquia_lift_personalize_campaign_wizard_targeting_ajax',
         'wrapper' => $main_wrapper_id,
@@ -1986,6 +1981,7 @@ function _acquia_lift_personalize_campaign_wizard_targeting_audience(&$form, &$f
     '#value' => 'add_context_' . $parent_identifier,
     '#theme_wrappers' => array('personalize_html_tag'),
     '#submit' => array('acquia_lift_personalize_campaign_wizard_targeting_add'),
+    '#name' => 'audiences[' . $parent_identifier . '][details][add_new]',
     '#attributes' => array(
       'class' => array('personalize-add-link'),
       'title' => t('Click here to add more contexts.'),
@@ -1996,6 +1992,7 @@ function _acquia_lift_personalize_campaign_wizard_targeting_audience(&$form, &$f
       'wrapper' => $main_wrapper_id,
       'effect' => 'fade',
     ),
+    '#skip_validation' => TRUE,
   );
   $element['strategies'] = array(
     '#type' => 'container',

--- a/acquia_lift.admin.wizard.inc
+++ b/acquia_lift.admin.wizard.inc
@@ -436,7 +436,10 @@ function acquia_lift_personalize_campaign_wizard_goals_alter(&$form, &$form_stat
     switch ($form_state['values']['goals']['add_goal']['goal_types']['goal_type']) {
       case 'existing':
         $form['goals']['add_goal']['goal']['details'] = _acquia_lift_existing_goal_create_form($agent_data);
+        // TRICKY: Name must be specified or else it will default to "op" and
+        // conflict with the main process bar save button.
         $form['goals']['add_goal']['goal']['save'] = array(
+          '#name' => 'save_goal',
           '#type' => 'submit',
           '#value' => t('Save'),
         );
@@ -456,7 +459,10 @@ function acquia_lift_personalize_campaign_wizard_goals_alter(&$form, &$form_stat
           '#required' => TRUE,
           '#weight' => 10,
         );
+        // TRICKY: Name must be specified or else it will default to "op" and
+        // conflict with the main process bar save button.
         $form['goals']['add_goal']['goal']['save'] = array(
+          '#name' => 'save_new_goal',
           '#type' => 'submit',
           '#value' => t('Save'),
         );
@@ -563,7 +569,10 @@ function acquia_lift_personalize_campaign_wizard_targeting_alter(&$form, &$form_
     '#access' => $editable,
   );
   $form['targeting']['audiences']['add']['details'] = _acquia_lift_personalize_campaign_wizard_targeting_audience($form, $form_state, $agent_data, 'add');
-  $form['targeting']['audiences']['add']['save'] = array(
+  // TRICKY: Name must be specified or else it will default to "op" and
+  // conflict with the main process bar save button.
+  $form['targeting']['audiences']['add']['save_audience'] = array(
+    '#name' => 'save_new_audience',
     '#type' => 'submit',
     '#value' => t('Save'),
   );

--- a/acquia_lift.admin.wizard.inc
+++ b/acquia_lift.admin.wizard.inc
@@ -1943,6 +1943,7 @@ function _acquia_lift_personalize_campaign_wizard_targeting_audience(&$form, &$f
       '#text' => t('Remove'),
       '#value' => 'remove_' . $delta,
       '#theme_wrappers' => array('personalize_html_tag'),
+      '#access' => count($mappings) > 1,
       '#attributes' => array(
         'class' => array('personalize-delete-context', 'form-submit',),
         'title' => t('Delete this context.'),

--- a/acquia_lift.admin.wizard.inc
+++ b/acquia_lift.admin.wizard.inc
@@ -1061,14 +1061,60 @@ function acquia_lift_personalize_campaign_wizard_goals_validate(&$form, &$form_s
  * Validation function for targeting form.
  */
 function acquia_lift_personalize_campaign_wizard_targeting_validate(&$form, &$form_state) {
-  // Verify that a new audience will have a unique machine name.
-  if (!empty($form_state['values']['audiences']['add']['details']['name'])) {
-    module_load_include('inc', 'acquia_lift', 'acquia_lift.admin');
-    $machine_name = personalize_generate_machine_name($form_state['values']['audiences']['add']['details']['name'], NULL, '-');
-    $agent_data = $form['#agent'];
-    $option_set = acquia_lift_get_option_set_for_targeting($agent_data->machine_name);
-    if (isset($option_set->targeting[$machine_name])) {
-      form_set_error('audiences[add][details][name', t('Please choose a different name for your audience as this one is already taken'));
+  // If we are adding - then validate the required audience fields.
+  if (in_array('add', $form_state['triggering_element']['#array_parents'])) {
+    if (empty($form_state['values']['audiences']['add']['details']['name'])) {
+      form_set_error('audiences[add][details][name', t('You must specify the name of the new audience.'));
+    }
+    else {
+      // Verify that a new audience will have a unique machine name.
+      module_load_include('inc', 'acquia_lift', 'acquia_lift.admin');
+      $machine_name = personalize_generate_machine_name($form_state['values']['audiences']['add']['details']['name'], NULL, '-');
+      $agent_data = $form['#agent'];
+      $option_set = acquia_lift_get_option_set_for_targeting($agent_data->machine_name);
+      if (isset($option_set->targeting[$machine_name])) {
+        form_set_error('audiences[add][details][name', t('Please choose a different name for your audience as this one is already taken'));
+      }
+    }
+  }
+  // Make sure that there is at least one filled in context.
+  foreach ($form_state['values']['audiences'] as $audience_id => $audience) {
+    if ($audience_id === ACQUIA_LIFT_TARGETING_EVERYONE_ELSE) {
+      continue;
+    }
+    if (empty($audience['details']['name'])) {
+      continue;
+    }
+    $has_context = FALSE;
+    $audience_label = $audience['details']['name'];
+    foreach (element_children($audience['details']['mapping']['contexts']) as $index) {
+      if (!empty($audience['details']['mapping']['contexts'][$index]['context'])) {
+        $has_operator = !empty($audience['details']['mapping']['contexts'][$index]['value']['operator']);
+        $has_value = !empty($audience['details']['mapping']['contexts'][$index]['value']['match']);
+        $context_value = $audience['details']['mapping']['contexts'][$index]['context'];
+        $context_label = $form['targeting']['audiences'][$audience_id]['details']['mapping']['contexts'][$index]['context']['#options'][$context_value];
+        // Make sure that an operator and value have been entered.
+        if (!$has_operator) {
+          form_set_error('audiences[' . $audience_id . '][details][mapping][contexts][' . $index . '][value][operator', t('Please choose the operator for %context in the %audience audience.', array(
+            '%context' => $context_label,
+            '%audience' => $audience_label,
+          )));
+        }
+        if (!$has_value) {
+          form_set_error('audiences[' . $audience_id . '][details][mapping][contexts][' . $index . '][value][match', t('Please choose the value for %context context in the %audience audience.', array(
+            '%context' => $context_label,
+            '%audience' => $audience_label,
+          )));
+        }
+        if ($has_operator && $has_value) {
+          $has_context = TRUE;
+        }
+      }
+    }
+    if (!$has_context) {
+      form_set_error('audiences[' . $audience_id . '][details][mapping][contexts][add][context', t('Please select at least one context to define the %audience audience.', array(
+        '%audience' => $audience_label,
+      )));
     }
   }
 }

--- a/acquia_lift.admin.wizard.inc
+++ b/acquia_lift.admin.wizard.inc
@@ -918,6 +918,7 @@ function acquia_lift_personalize_campaign_wizard_goals_ajax_all($form, &$form_st
 function acquia_lift_personalize_campaign_wizard_targeting_add($form, &$form_state) {
   // Increment the number of contexts to be rendered.
   $context_key = $form_state['triggering_element']['#array_parents'][2];
+  watchdog('debug', 'adding context to ' . $context_key);
   $form_state['num_contexts_audience'][$context_key]++;
   $form_state['rebuild'] = TRUE;
 }
@@ -926,8 +927,10 @@ function acquia_lift_personalize_campaign_wizard_targeting_add($form, &$form_sta
  * Submit handler for the "Remove Context" button.
  */
 function acquia_lift_personalize_campaign_wizard_targeting_remove($form, &$form_state) {
-  $context_key = $form_state['triggering_element']['#array_parents'][1];
-  $parents = $form_state['clicked_button']['#parents'];
+  $parents = $form_state['triggering_element']['#parents'];
+  $context_key_pos = array_search('audiences', $parents) + 1;
+  $context_key = $parents[$context_key_pos];
+  watchdog('debug', 'removing context from ' . $context_key);
   $delta_pos = array_search('contexts', $parents) + 1;
   $delta = $parents[$delta_pos];
   $form_state['to_remove_audience'][$context_key] = $delta;
@@ -940,7 +943,10 @@ function acquia_lift_personalize_campaign_wizard_targeting_remove($form, &$form_
 function acquia_lift_personalize_campaign_wizard_targeting_ajax($form, &$form_state) {
   // Don't show any messages within the AJAX returned.
   drupal_get_messages();
+  watchdog('debug', 'parents: <pre>' . print_r($form_state['triggering_element']['#parents'], TRUE) . '</pre>');
+  watchdog('debug', 'search for audiences: ' . (array_search('audiences',$form_state['triggering_element']['#parents']) + 1));
   $context_key = $form_state['triggering_element']['#array_parents'][2];
+  watchdog('debug', 'returning context ' . $context_key);
   return $form['targeting']['audiences'][$context_key]['details']['mapping']['contexts'];
 }
 
@@ -1867,6 +1873,20 @@ function _acquia_lift_personalize_campaign_wizard_targeting_audience(&$form, &$f
       '#value' => t('Definition'),
     ))),
   );
+
+  if (isset($form_state['to_remove_audience'])) {
+    watchdog('debug', 'remove audiences: <pre>' . print_r($form_state['to_remove_audience'], TRUE) . '</pre>');
+  }
+  else {
+    watchdog('debug', 'nothing to remove');
+  }
+  if (isset($form_state['num_contexts_audience'])) {
+    watchdog('debug', 'num contexts audiences: <pre>' . print_r($form_state['num_contexts_audience'], TRUE) . '</pre>');
+  }
+  else {
+    watchdog('debug', 'no context number set');
+  }
+
 
   // Load from the existing form if passed first, otherwise, load from audience.
   $mappings = array();

--- a/acquia_lift.admin.wizard.inc
+++ b/acquia_lift.admin.wizard.inc
@@ -929,7 +929,6 @@ function acquia_lift_personalize_campaign_wizard_targeting_add($form, &$form_sta
   $parents = $form_state['triggering_element']['#parents'];
   $context_key_pos = array_search('audiences', $parents) + 1;
   $context_key = $parents[$context_key_pos];
-  watchdog('debug', 'adding context to ' . $context_key);
   $form_state['num_contexts_audience'][$context_key]++;
   $form_state['rebuild'] = TRUE;
 }
@@ -941,7 +940,6 @@ function acquia_lift_personalize_campaign_wizard_targeting_remove($form, &$form_
   $parents = $form_state['triggering_element']['#parents'];
   $context_key_pos = array_search('audiences', $parents) + 1;
   $context_key = $parents[$context_key_pos];
-  watchdog('debug', 'removing context from ' . $context_key);
   $delta_pos = array_search('contexts', $parents) + 1;
   $delta = $parents[$delta_pos];
   $form_state['to_remove_audience'][$context_key] = $delta;
@@ -957,7 +955,6 @@ function acquia_lift_personalize_campaign_wizard_targeting_ajax($form, &$form_st
   $parents = $form_state['triggering_element']['#parents'];
   $context_key_pos = array_search('audiences', $parents) + 1;
   $context_key = $parents[$context_key_pos];
-  watchdog('debug', 'returning context ' . $context_key);
   return $form['targeting']['audiences'][$context_key]['details']['mapping']['contexts'];
 }
 


### PR DESCRIPTION
CH-2857: On Who page - Context "Remove" button doesn't work
CH-2858: On Who page - Shouldn't be able to create a Definition of empty value
CH-2859: On Who page - Save Definition of empty "Audience name" fails silently
