### PR TITLE
Ch 3075: Allow basic element variation set editing from workflow

### DIFF
--- a/acquia_lift.admin.wizard.inc
+++ b/acquia_lift.admin.wizard.inc
@@ -1721,6 +1721,8 @@ function _acquia_lift_personalize_campaign_wizard_block_single_save($block_conte
  *   The option set to be edited.
  */
 function _acquia_lift_personalize_campaign_wizard_element_single_save($values, $option_set) {
+  // Make sure to start with the latest option set information.
+  $option_set = personalize_option_set_load($option_set->osid);
   $option_set->label = $values['label'];
   foreach ($option_set->options as &$option) {
     $option['option_label'] = $values['options'][$option['option_id']]['option_label'];
@@ -1738,6 +1740,7 @@ function _acquia_lift_personalize_campaign_wizard_element_single_save($values, $
  *   The option set object submitted with the form.
  */
 function _acquia_lift_personalize_campaign_wizard_variations_single_save_general($values, $option_set) {
+  // Make sure to start with the latest option set information.
   $option_set = personalize_option_set_load($option_set->osid);
   // Advanced form expects the label within its options.
   if (isset($values['content'])) {

--- a/acquia_lift.admin.wizard.inc
+++ b/acquia_lift.admin.wizard.inc
@@ -1704,6 +1704,22 @@ function _acquia_lift_personalize_campaign_wizard_block_single_save($block_conte
 }
 
 /**
+ * Helper submit function to save a single existing element variation.
+ *
+ * @param array $values
+ *   The values from the form state specific to this option set
+ * @param stdClass $option_set
+ *   The option set to be edited.
+ */
+function _acquia_lift_personalize_campaign_wizard_element_single_save($values, $option_set) {
+  $option_set->label = $values['label'];
+  foreach ($option_set->options as &$option) {
+    $option['option_label'] = $values['options'][$option['option_id']]['option_label'];
+  }
+  personalize_option_set_save($option_set);
+}
+
+/**
  * Submit function to submit a single new block variation.
  */
 function acquia_lift_personalize_campaign_wizard_variations_single_submit($form, $form_state) {
@@ -1728,7 +1744,8 @@ function acquia_lift_personalize_campaign_wizard_variations_submit(&$form, &$for
         case "block":
           _acquia_lift_personalize_campaign_wizard_block_single_save($option_set_values['content'], $option_set, $form_state);
           break;
-        case "element":
+        case "elements":
+          _acquia_lift_personalize_campaign_wizard_element_single_save($option_set_values['content'], $option_set);
           break;
         default:
           // Unsupported option set type.
@@ -2398,25 +2415,41 @@ function _acquia_lift_personalize_campaign_wizard_variations_element(&$form, &$f
     return $element;
   }
   // Form for an existing option set.
+  $editable = acquia_lift_target_definition_changes_allowed($agent_data);
   $element['label'] = array(
     '#type' => 'textfield',
     '#required' => TRUE,
-    '#theme_wrappers' => array('acquia_lift_revealing_input'),
     '#default_value' => $option_set->label,
     '#title' => t('Variation set')
   );
-  $items = array();
+  $show_delete = $editable && count($option_set->options) > 2;
   foreach ($option_set->options as $option) {
-    $items[] = $option['option_label'];
-  };
-  if (!empty($items)) {
-    $element['display'] = array(
-      '#markup' => theme('item_list', array(
-        'items' => $items,
-        'title' => t('Variations'),
-      )),
+    $option_id = $option['option_id'];
+    $element['options'][$option_id] = array(
+      '#type' => 'container',
+      '#attributes' => array(
+        'class' => array('acquia-lift-element-variations'),
+      ),
     );
-  }
+    $element['options'][$option_id]['option_label'] = array(
+      '#type' => 'textfield',
+      '#required' => TRUE,
+      '#default_value' => $option['option_label'],
+      '#title' => t('Variation'),
+      '#theme_wrappers' => array('acquia_lift_revealing_input'),
+    );
+    if ($show_delete) {
+      $remove_url = "admin/structure/personalize/variations/personalize-elements/manage/{$option_set->osid}/{$option_id}/delete";
+      $element['options'][$option_id]['remove'] = array(
+        '#markup' => l(t('Delete'), $remove_url, array(
+          'attributes' => array(
+            'class' => array('acquia-lift-delete'),
+          ),
+          'query' => array('destination' => 'admin/structure/personalize/manage/' . $agent_data->machine_name . '/variations'),
+        )),
+      );
+    }
+  };
   if (!empty($option_set->data['pages'])) {
     // Note that utilizing the personalize_html_tag theme here somehow prevents
     // the element and form-altered submit handlers from being called.

--- a/acquia_lift.admin.wizard.inc
+++ b/acquia_lift.admin.wizard.inc
@@ -199,6 +199,15 @@ function acquia_lift_personalize_campaign_wizard_variations_alter(&$form, &$form
     $form['variations']['editing']['option_sets']['option_set_' . $option_set->osid]['advanced']['label']['#access'] = FALSE;
     // Decision name is handled based on the type of tests created.
     $form['variations']['editing']['option_sets']['option_set_' . $option_set->osid]['advanced']['decision_name']['#access'] = FALSE;
+
+    // Show save button specific to this option set.
+    $form['variations']['editing']['option_sets']['option_set_' . $option_set->osid]['save'] = array(
+      '#name' => $option_set->plugin . '_existing_' . $option_set->osid,
+      '#type' => 'submit',
+      '#value' => t('Save'),
+      '#submit' => array('acquia_lift_personalize_campaign_wizard_variations_single_submit'),
+      '#limit_validation_errors' => array(array('variations', 'editing', 'option_sets', 'option_set_' . $option_set->osid)),
+    );
   }
   // Hide the agent advanced options which will be shown on the review screen.
   $form['variations']['editing']['advanced']['#access'] = FALSE;
@@ -288,7 +297,7 @@ function acquia_lift_personalize_campaign_wizard_variations_alter(&$form, &$form
             // TRICKY: Name must be specified or else it will default to "op" and
             // conflict with the main process bar save button.
             $form['variations']['editing']['new'][$delta]['block']['save'] = array(
-              '#name' => 'single_save_' . $delta,
+              '#name' => 'block_new_' . $delta,
               '#type' => 'submit',
               '#value' => t('Save'),
               '#submit' => array('acquia_lift_personalize_campaign_wizard_variations_single_submit'),
@@ -1720,11 +1729,52 @@ function _acquia_lift_personalize_campaign_wizard_element_single_save($values, $
 }
 
 /**
+ * Helper submit function to submit the general and advanced information
+ * for an existing option set.
+ *
+ * @param array $values
+ *   The form state values specific to the option set.
+ * @param stdClass $option_set
+ *   The option set object submitted with the form.
+ */
+function _acquia_lift_personalize_campaign_wizard_variations_single_save_general($values, $option_set) {
+  $option_set = personalize_option_set_load($option_set->osid);
+  // Advanced form expects the label within its options.
+  if (isset($values['content'])) {
+    $option_label = isset($values['content']['title']) ? $values['content']['title'] : $values['content']['label'];
+    $option_set->label = $option_label;
+    $values['advanced']['label'] = $option_label;
+  }
+  personalize_campaign_wizard_submit_variations_advanced($values, $option_set);
+  personalize_option_set_save($option_set);
+}
+
+/**
  * Submit function to submit a single new block variation.
  */
 function acquia_lift_personalize_campaign_wizard_variations_single_submit($form, $form_state) {
-  list( , , $delta) = explode('_', $form_state['triggering_element']['#name']);
-  _acquia_lift_personalize_campaign_wizard_block_single_save($form_state['values']['variations']['editing']['new'][$delta]['block']['content'], NULL, $form_state);
+  // Triggering submit name is {type}_{existing}_{delta} where
+  // {type} is the option set plugin
+  // {existing} is 'new' or 'existing'
+  // {delta} is the option set id for an existing edit or the index for a new
+  list($type, $existing, $delta) = explode('_', $form_state['triggering_element']['#name']);
+  $option_set = $existing == 'existing' ? $form_state['values']['variations']['editing']['option_sets']['option_set_' . $delta]['option_set'] : NULL;
+  switch ($type) {
+    case 'block':
+      if ($existing == 'new') {
+        _acquia_lift_personalize_campaign_wizard_block_single_save($form_state['values']['variations']['editing']['new'][$delta]['block']['content'], NULL, $form_state);
+      }
+      else {
+        _acquia_lift_personalize_campaign_wizard_block_single_save($form_state['values']['variations']['editing']['option_sets']['option_set_' . $delta]['content'], $option_set, $form_state);
+      }
+      break;
+    case 'elements':
+      // Only existing elements can be saved this way.
+      _acquia_lift_personalize_campaign_wizard_element_single_save($form_state['values']['variations']['editing']['option_sets']['option_set_' . $delta]['content'], $option_set);
+  }
+  if ($existing == 'existing') {
+    _acquia_lift_personalize_campaign_wizard_variations_single_save_general($form_state['values']['variations']['editing']['option_sets']['option_set_' . $delta], $option_set);
+  }
 }
 
 /**
@@ -1750,15 +1800,8 @@ function acquia_lift_personalize_campaign_wizard_variations_submit(&$form, &$for
         default:
           // Unsupported option set type.
       }
-      $option_set = personalize_option_set_load($option_set->osid);
-      // Advanced form expects the label within its options.
-      if (isset($option_set_values['content'])) {
-        $option_label = isset($option_set_values['content']['title']) ? $option_set_values['content']['title'] : $option_set_values['content']['label'];
-        $option_set->label = $option_label;
-        $option_set_values['advanced']['label'] = $option_label;
-      }
-      personalize_campaign_wizard_submit_variations_advanced($option_set_values, $option_set);
-      personalize_option_set_save($option_set);
+      // Save general and advanced option set data.
+      _acquia_lift_personalize_campaign_wizard_variations_single_save_general($option_set_values, $option_set);
     }
   }
 

--- a/css/acquia_lift.admin.css
+++ b/css/acquia_lift.admin.css
@@ -454,7 +454,7 @@ input[type="submit"].acquia-lift-wizard-add:hover {
 }
 .personalize-wizard-section .acquia-lift-element-variations {
   width: 100%;
-  padding: 1em 0;
+  padding: 1em 0 .5em 0;
 }
 .personalize-wizard-section .acquia-lift-element-variations + .acquia-lift-element-variations {
   border-top: 1px solid #cccccc;

--- a/css/acquia_lift.admin.css
+++ b/css/acquia_lift.admin.css
@@ -448,6 +448,22 @@ input[type="submit"].acquia-lift-wizard-add:hover {
   max-height: 200rem;
 }
 
+.personalize-wizard-section .acquia-lift-element-variations,
+.personalize-wizard-section .acquia-lift-element-variations > * {
+  display: inline-block;
+}
+.personalize-wizard-section .acquia-lift-element-variations {
+  width: 100%;
+  padding: 1em 0;
+}
+.personalize-wizard-section .acquia-lift-element-variations + .acquia-lift-element-variations {
+  border-top: 1px solid #cccccc;
+}
+.personalize-wizard-section .acquia-lift-element-variations .acquia-lift-delete {
+  float: right; /* RTL */
+  margin-right: .25rem /* RTL */
+}
+
 /* Targeting form */
 .acquia-lift-targeting .personalize-target-wrapper .form-item,
 .acquia-lift-targeting .personalize-target-wrapper .personalize-target-value,

--- a/tests/acquia_lift.test
+++ b/tests/acquia_lift.test
@@ -2999,6 +2999,18 @@ class AcquiaLiftWebTestCampaignWizardVariations extends AcquiaLiftWebTestCampaig
     $this->assertTrue($settings['acquia_lift']['option_sets'][$js_osid]['option-A']['deletable']);
     $this->assertTrue($settings['acquia_lift']['option_sets'][$js_osid]['option-B']['editable']);
     $this->assertTrue($settings['acquia_lift']['option_sets'][$js_osid]['option-B']['deletable']);
+
+    // Verify that the elements variation can have general edits made from
+    // the campaign workflow.
+    $this->drupalGet('admin/structure/personalize/manage/' . $agent->machine_name . '/variations');
+    $edit = array(
+      'variations[editing][option_sets][option_set_' . $option_set->osid . '][content][label]' => 'Element test set 1 - EDIT',
+      'variations[editing][option_sets][option_set_' . $option_set->osid . '][content][options][option-A][option_label]' => 'Option A - EDIT',
+    );
+    $this->drupalPost(NULL, $edit, $this->getButton('wizard_next', array('agent_name' => $agent->machine_name, 'step' => 'variations')));
+    $option_set = personalize_option_set_load($option_set->osid, TRUE);
+    $this->assertTrue('Element test set 1 - EDIT', $option_set->label);
+    $this->assertTrue('Option A - EDIT', $option_set->label);
   }
 
   /**


### PR DESCRIPTION
Allows editing the options labels and removing an option from the workflow to make the presentation similar to blocks.
