### PR TITLE
Issue #2430417 follow-up by ynx: if the everyone-else audience is the…

### DIFF
--- a/acquia_lift.admin.inc
+++ b/acquia_lift.admin.inc
@@ -1723,7 +1723,7 @@ function acquia_lift_target_option_set_targeted($agent_name, $option_set) {
  */
 function _acquia_lift_personalize_campaign_wizard_everyone_else_audience() {
   return array(
-    'name' => t('Everyone else'),
+    'name' => t('Everyone'),
     'contexts' => array(),
     'weight' => 1,
     'strategy' => 'OR',

--- a/acquia_lift.install
+++ b/acquia_lift.install
@@ -727,7 +727,7 @@ function acquia_lift_update_7200() {
         $main_os->decision_name = $option_set_details['decision_name'];
         $main_os->targeting = array(
           ACQUIA_LIFT_TARGETING_EVERYONE_ELSE => array(
-            'label' => t('Everyone else'),
+            'label' => t('Everyone'),
             'weight' => 1,
             'targeting_features' => array(),
             'targeting_rules' => array (),

--- a/acquia_lift.module
+++ b/acquia_lift.module
@@ -637,7 +637,14 @@ function acquia_lift_personalize_goal_presave($goal) {
  * Implements hook_personalize_option_set_presave().
  */
 function acquia_lift_personalize_option_set_presave($option_set) {
-  // Only applies to saving of existing option sets.
+  // If the everyone-else audience is the only audience, name it "Everyone";
+  // otherwise name it "Everyone else".
+  if (isset($option_set->targeting[ACQUIA_LIFT_TARGETING_EVERYONE_ELSE])) {
+    $everyone_else_name = count($option_set->targeting) > 1 ? t('Everyone else') : t("Everyone");
+    $option_set->targeting[ACQUIA_LIFT_TARGETING_EVERYONE_ELSE]['label'] = $everyone_else_name;
+  }
+
+  // The rest only applies to saving of existing option sets.
   if (empty($option_set->osid)) {
     return;
   }

--- a/tests/acquia_lift.test
+++ b/tests/acquia_lift.test
@@ -729,7 +729,7 @@ class AcquiaLiftWebTestAgentAdmin extends AcquiaLiftWebTestBase {
     $this->assertNoLinkByHref('admin/structure/personalize/manage/' . $agent->machine_name . '/delete');
     $this->assertNoLinkByHref('admin/structure/personalize/manage/' . $agent->machine_name . '/results');
     $this->assertText(t('Test only'));
-    $this->assertText(t('Everyone else'));
+    $this->assertText(t('Everyone'));
 
     // Add two audiences and assign variations so that there is only targeting.
     $audience_1 = personalize_generate_machine_name($this->randomName(), NULL, '-');
@@ -1009,7 +1009,7 @@ class AcquiaLiftWebTestReports extends AcquiaLiftWebTestBase {
     personalize_agent_set_status($agent->machine_name, PERSONALIZE_STATUS_RUNNING);
     $this->resetAll();
     $this->drupalGet('admin/structure/personalize/manage/' . $agent->machine_name . '/results');
-    $this->assertText('Test for Everyone else audience');
+    $this->assertText('Test for Everyone audience');
     $this->assertNoFieldByName('audience_filter');
 
     // Pause the agent and change it so that it has another test.
@@ -1857,7 +1857,7 @@ class AcquiaLiftWebTestTarget extends AcquiaLiftWebTestBase {
     $expected = array (
       ACQUIA_LIFT_TARGETING_EVERYONE_ELSE =>
         array (
-          'label' => t('Everyone else'),
+          'label' => t('Everyone'),
           'weight' => 1,
           'targeting_features' => array(),
           'targeting_rules' => array (),


### PR DESCRIPTION
… only audience, name it "Everyone"; otherwise name it "Everyone else".
