### PR TITLE
CHMS-1012: Initial Drupal 7 offering for Lift 3

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,0 +1,34 @@
+*******************************************************************************
+
+Acquia Lift
+
+
+Description:
+-------------------------------------------------------------------------------
+
+Acquia Lift lets you track customers' behavior throughout their buying journey —
+from anonymous visitor to loyal, repeat customer — by creating a unified
+customer profile for each individual. Using Acquia Lift, you can now bring
+together content and customer data from any channel to personalize customers'
+experiences across websites regardless of the content management system that you
+use. Acquia Lift adaptively segments your customers in real-time, letting you
+deliver personalized content that furthers your website visitors' engagement
+with your brand.
+
+The latest stable releases can be found on at
+https://www.drupal.org/project/acquia_lift/releases. Please contact your Acquia
+Solution Architect or Account Manager, and they will be happy to help you with
+on-boarding.
+
+
+Installation
+-------------------------------------------------------------------------------
+See https://docs.acquia.com/lift/drupal/3/install
+
+Documentation
+-------------
+See https://docs.acquia.com/lift/3
+
+Running Tests
+-------------
+You can run Acquia Lift tests through the simpletest UI.

--- a/acquia_lift.admin.inc
+++ b/acquia_lift.admin.inc
@@ -1,0 +1,410 @@
+<?php
+
+/**
+ * @file acquia_lift.admin.inc
+ * Provides functions needed for the admin UI.
+ */
+
+
+function acquia_lift_admin_form($form, &$form_state) {
+  $is_configured = acquia_lift_is_configured();
+  $form['credentials'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Acquia Lift credential'),
+    '#collapsible' => $is_configured,
+    '#collapsed' => $is_configured,
+    '#tree' => FALSE,
+  );
+  _acquia_lift_admin_build_credential_form($form['credentials'], $form_state);
+
+  $form['data_collection'] = array(
+    '#type' => 'vertical_tabs',
+    '#title' => t('Data collection settings'),
+  );
+
+  $form['identity'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Identity'),
+    '#group' => 'data_collection',
+    '#collapsible' => TRUE,
+    '#tree' => FALSE,
+    '#weight' => 10,
+  );
+  _acquia_lift_admin_build_identity_form($form['identity'], $form_state);
+
+  $form['acquia_lift_field_mappings'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Field mappings'),
+    '#description' => t('Create !taxonomy_link and map to "content section", "content keywords", and "persona" fields.', array(
+        '!taxonomy_link' => l(t('Taxonomy Vocabulary'), 'admin/structure/taxonomy'))
+    ),
+    '#group' => 'data_collection',
+    '#collapsible' => TRUE,
+    '#tree' => TRUE,
+    '#weight' => 20,
+  );
+  _acquia_lift_admin_build_field_mappings_form($form['acquia_lift_field_mappings'], $form_state);
+
+  $form['acquia_lift_udf_mappings'] = array(
+    '#tree' => TRUE,
+  );
+  $form['acquia_lift_udf_mappings']['person'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('User person mappings'),
+    '#description' => t('Map taxonomy terms to Visitor Profile person fields in Acquia Lift. Select a Taxonomy Reference Field that, if present, will map the value of the specified field to the Acquia Lift Profile for that specific visitor. No options available? Create !taxonomy_vocabulary_link and map the corresponding value.', array(
+        '!taxonomy_vocabulary_link' => l(t('Taxonomy Vocabulary'), 'admin/structure/taxonomy'))
+    ),
+    '#group' => 'data_collection',
+    '#collapsible' => TRUE,
+    '#weight' => 30,
+  );
+  _acquia_lift_admin_build_udf_mappings_form($form['acquia_lift_udf_mappings']['person'], $form_state, 'person');
+
+  $form['acquia_lift_udf_mappings']['touch'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('User touch mappings'),
+    '#description' => t('Map taxonomy terms to Visitor Profile touch fields in Acquia Lift. Select a Taxonomy Reference Field that, if present, will map the value of the specified field to the Acquia Lift Profile for that specific visitor. No options available? Create !taxonomy_vocabulary_link and map the corresponding value.', array(
+      '!taxonomy_vocabulary_link' => l(t('Taxonomy Vocabulary'), 'admin/structure/taxonomy'))
+    ),
+    '#group' => 'data_collection',
+    '#collapsible' => TRUE,
+    '#weight' => 40,
+  );
+  _acquia_lift_admin_build_udf_mappings_form($form['acquia_lift_udf_mappings']['touch'], $form_state, 'touch');
+
+  $form['acquia_lift_udf_mappings']['event'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('User event mappings'),
+    '#description' => t('Map taxonomy terms to Visitor Profile event fields in Acquia Lift. Select a Taxonomy Reference Field that, if present, will map the value of the specified field to the Acquia Lift Profile for that specific visitor. No options available? Create !taxonomy_vocabulary_link and map the corresponding value.', array(
+        '!taxonomy_vocabulary_link' => l(t('Taxonomy Vocabulary'), 'admin/structure/taxonomy'))
+    ),
+    '#group' => 'data_collection',
+    '#collapsible' => TRUE,
+    '#weight' => 50,
+  );
+  _acquia_lift_admin_build_udf_mappings_form($form['acquia_lift_udf_mappings']['event'], $form_state, 'event');
+
+  $form['visibility'] = array(
+    '#type' => 'fieldset',
+    '#description' => t('Lift will skip data collection on those URLs and their aliases.'),
+    '#title' => t('Visibility'),
+    '#group' => 'data_collection',
+    '#collapsible' => TRUE,
+    '#tree' => FALSE,
+    '#weight' => 60,
+  );
+  _acquia_lift_admin_build_visibility_form($form['visibility'], $form_state);
+
+  $form['advanced'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Advanced configuration'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+    '#tree' => FALSE,
+    '#weight' => 70,
+  );
+  _acquia_lift_admin_build_advanced_confirmation_form($form['advanced'], $form_state);
+  $form['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Save configuration'),
+    '#weight' => 80,
+  );
+  return $form;
+}
+
+function _acquia_lift_admin_build_credential_form(&$form, &$form_state) {
+  $form['acquia_lift_account_id'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Account ID'),
+    '#description' => t('Your Lift subscription\'s account ID.'),
+    '#default_value' => variable_get('acquia_lift_account_id', ''),
+    '#required' => TRUE,
+  );
+  $form['acquia_lift_site_id'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Site ID'),
+    '#description' => t('Current site\'s site ID. WARNING: different sites must use different value here, even between a staging and a production of the same site.'),
+    '#default_value' => variable_get('acquia_lift_site_id', ''),
+    '#required' => TRUE,
+  );
+  $form['acquia_lift_assets_url'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Assets URL'),
+    '#description' => t('Your Lift application\'s assets URL.  It determines which version of the Lift application is being used.'),
+    '#field_prefix' => 'https://',
+    '#default_value' => _acquia_lift_admin_clean_url(variable_get('acquia_lift_assets_url', '')),
+    '#required' => TRUE,
+  );
+  $form['acquia_lift_decision_api_url'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Decision API URL'),
+    '#description' => t('Your Lift Decision API\'s URL.  Unless explicitly instructed, leave empty to use default URL.'),
+    '#field_prefix' => 'https://',
+    '#default_value' => _acquia_lift_admin_clean_url(variable_get('acquia_lift_decision_api_url', '')),
+  );
+  $form['acquia_lift_oauth_url'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Authentication URL'),
+    '#description' => t('Your Lift Authentication API\'s URL.  Unless explicitly instructed, leave empty to use default URL.'),
+    '#field_prefix' => 'https://',
+    '#field_suffix' => '/authorize',
+    '#default_value' => _acquia_lift_admin_clean_url(_acquia_lift_admin_remove_authorize_suffix(variable_get('acquia_lift_oauth_url', ''))),
+  );
+  return $form;
+}
+
+
+/**
+ * Admin form for configuring acquia_lift behavior.
+ */
+function _acquia_lift_admin_build_identity_form(&$form, &$form_state) {
+  $identity_parameter_display_value = variable_get('acquia_lift_identity_param', 'identity');
+  $identity_type_parameter_display_value = variable_get('acquia_lift_identity_type_param', 'identityType');
+  $default_identity_type_display_value = variable_get('acquia_lift_default_identity_type', ACQUIA_LIFT_DEFAULT_IDENTITY_TYPE_IDENTIFIER);
+  $default_identity_type_default_value = variable_get('acquia_lift_default_identity_type', ACQUIA_LIFT_DEFAULT_IDENTITY_TYPE_DEFAULT);
+
+  $form['acquia_lift_identity_param'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Identity Parameter'),
+    '#description' => t('The query string parameter for specific visitor information, such as an email address or social media username, which is sent to the Acquia Lift service. Example: ?<ins>@identity_parameter_display_value</ins>=jdoe01', [
+      '@identity_parameter_display_value' => $identity_parameter_display_value,
+    ]),
+    '#default_value' => variable_get('acquia_lift_identity_param'),
+  );
+  $form['acquia_lift_identity_type_param'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Identity Type Parameter'),
+    '#description' => t('The query string parameter for the category (standard or custom) of the visitor\'s identity information. Example: ?@identity_parameter_display_value=jdoe01&<ins>@identity_type_parameter_display_value</ins>=@default_identity_type_default_value', [
+      '@identity_parameter_display_value' => $identity_parameter_display_value,
+      '@identity_type_parameter_display_value' => $identity_type_parameter_display_value,
+      '@default_identity_type_default_value' => $default_identity_type_default_value,
+    ]),
+    '#default_value' => variable_get('acquia_lift_identity_type_param'),
+    '#states' => array(
+      'visible' => array(
+        ':input[name="acquia_lift_identity_param"]' => ['!value' => ''],
+      ),
+    ),
+  );
+  $form['acquia_lift_default_identity_type'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Default Identity Type'),
+    '#description' => t('The identity type category to use by default. Leave this field blank to default to <ins>@default</ins>. Example: <ins>@default_identity_type_display_value</ins> is "?@identity_parameter_display_value=jdoe01&@identity_type_parameter_display_value=<ins>@default_identity_type_display_value</ins>", while blank is the same as "?@identity_parameter_display_value=jdoe01&@identity_type_parameter_display_value=<ins>@default</ins>"', [
+      '@default' => 'email',
+      '@identity_parameter_display_value' => $identity_parameter_display_value,
+      '@identity_type_parameter_display_value' => $identity_type_parameter_display_value,
+      '@default_identity_type_display_value' => $default_identity_type_display_value,
+    ]),
+    '#default_value' => variable_get('acquia_lift_default_identity_type'),
+    '#placeholder' => ACQUIA_LIFT_DEFAULT_IDENTITY_TYPE_DEFAULT,
+  );
+}
+
+function _acquia_lift_admin_build_field_mappings_form(&$form, &$form_state) {
+  // Retrieving all context options.
+  $groups = acquia_lift_get_grouped_context_options();
+
+  $field_list = array(
+    'content_section' => 'Content Section',
+    'content_keywords' => 'Content Keywords',
+    'persona' => 'Persona',
+  );
+  $field_mappings = variable_get('acquia_lift_field_mappings', array());
+  foreach ($field_list as $field_name => $field_friendly_name) {
+    $default_value = isset($field_mappings[$field_name]) ? $field_mappings[$field_name] : NULL;
+    $select = _acquia_lift_admin_build_visitor_context_select($groups, $default_value);
+    $form[$field_name] = $select;
+    $form[$field_name]['#title'] = t($field_friendly_name);
+  }
+}
+
+function _acquia_lift_admin_build_udf_mappings_form(&$form, &$form_state, $udf_type) {
+  $udf_mappings = variable_get('acquia_lift_udf_mappings', array());
+  $udf_options = acquia_lift_get_udfs($udf_type);
+
+  $groups = acquia_lift_get_grouped_context_options();
+
+  foreach($udf_options as $i => $udf_title) {
+    $default_value = isset($udf_mappings[$udf_type][$udf_title]) ? $udf_mappings[$udf_type][$udf_title] : NULL;
+    $select = _acquia_lift_admin_build_visitor_context_select($groups, $default_value);
+    $select['#title'] = t('User profile @type field @number', array(
+      '@type' => $udf_type,
+      '@number' => $i + 1,
+    ));
+    $form[$udf_title] = $select;
+  }
+}
+
+function _acquia_lift_admin_build_visibility_form(&$form, &$form_state) {
+  $form['acquia_lift_ignore_path_patterns'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Path patterns'),
+    '#default_value' => variable_get('acquia_lift_ignore_path_patterns', "/admin\n/admin/*\n/batch\n/node/add*\n/node/*/*\n/user/*/*\n/block/*"),
+  );
+}
+
+function _acquia_lift_admin_build_advanced_confirmation_form(&$form, &$form_state) {
+  $form['acquia_lift_content_replacement_mode'] = [
+    '#type' => 'radios',
+    '#title' => t('Content replacement mode'),
+    '#description' => t('The default, site-wide setting for <a href="@docs-link" target="_blank">content replacement mode</a>.', array(
+      '@docs-link' => 'https://docs.acquia.com/lift/drupal/3/config/trusted',
+    )),
+    '#default_value' => variable_get('acquia_lift_content_replacement_mode', 'untrusted'),
+    '#options' => ['trusted' => t('Trusted'), 'untrusted' => t('Untrusted')],
+  ];
+}
+
+/**
+ * Returns a visitor context single select box.
+ */
+function _acquia_lift_admin_build_visitor_context_select($groups, $default_value) {
+  if (count($groups) == 0) {
+    return FALSE;
+  }
+  $element = array(
+    '#type' => 'select',
+    '#empty_option' => t('- Not mapped -'),
+    '#options' => $groups,
+    '#default_value' => $default_value,
+  );
+  return $element;
+}
+
+function acquia_lift_admin_form_validate($form, &$form_state) {
+  if (!preg_match('/^[a-zA-Z_][a-zA-Z\\d_]*$/', $form_state['values']['acquia_lift_account_id'])) {
+    form_set_error('acquia_lift_account_id', t('Account ID contains invalid characters.  It has to start with a letter and contain only alphanumerical characters.'));
+  }
+  if (!empty($form_state['values']['acquia_lift_assets_url']) && !valid_url($form_state['values']['acquia_lift_assets_url'])) {
+    form_set_error('acquia_lift_assets_url', t('Assets URL is an invalid URL.'));
+  }
+  if (!empty($form_state['values']['acquia_lift_decision_api_url']) && !valid_url($form_state['values']['acquia_lift_decision_api_url'])) {
+    form_set_error('acquia_lift_decision_api_url', t('Decision API URL is an invalid URL.'));
+  }
+  if (!empty($form_state['values']['acquia_lift_oauth_url']) && !valid_url($form_state['values']['acquia_lift_oauth_url'])) {
+    form_set_error('acquia_lift_oauth_url', t('Authentication URL is an invalid URL.'));
+  }
+}
+
+/**
+ * Submit handler for the acquia_lift configuration form.
+ */
+function acquia_lift_admin_form_submit($form, &$form_state) {
+  // Field mappings.
+  if (isset($form_state['values']['acquia_lift_field_mappings'])) {
+    // Don't save empty entries.
+    $acquia_lift_field_mappings = array_filter($form_state['values']['acquia_lift_field_mappings']);
+    variable_set('acquia_lift_field_mappings', $acquia_lift_field_mappings);
+  }
+
+  if (isset($form_state['values']['acquia_lift_udf_mappings'])) {
+    $udf_types = acquia_lift_get_udf_types();
+    $acquia_lift_udf_mappings = array();
+    foreach($udf_types as $type => $count) {
+      if (isset($form_state['values']['acquia_lift_udf_mappings'][$type])) {
+        $acquia_lift_udf_mappings[$type] = array_filter($form_state['values']['acquia_lift_udf_mappings'][$type]);
+      }
+    }
+    $acquia_lift_udf_mappings = array_filter($acquia_lift_udf_mappings);
+    variable_set('acquia_lift_udf_mappings', $acquia_lift_udf_mappings);
+  }
+
+  // Enforce https and clean up the urls
+  $assets_url = $form_state['values']['acquia_lift_assets_url'];
+  $decision_api_url = $form_state['values']['acquia_lift_decision_api_url'];
+  $oauth_url = $form_state['values']['acquia_lift_oauth_url'];
+  if (!empty($assets_url)) {
+    $assets_url = 'https://' . _acquia_lift_admin_clean_url($assets_url);
+    _acquia_lift_ping('Assets', $assets_url);
+  }
+  if (!empty($decision_api_url)) {
+    $decision_api_url = 'https://' . _acquia_lift_admin_clean_url($decision_api_url);
+    _acquia_lift_ping('Decision API', $decision_api_url);
+  }
+  if (!empty($oauth_url)) {
+    $oauth_url = 'https://' . _acquia_lift_admin_remove_authorize_suffix(_acquia_lift_admin_clean_url($oauth_url)) . '/authorize';
+    _acquia_lift_ping('Authentication', $oauth_url);
+  }
+  variable_set('acquia_lift_assets_url', $assets_url);
+  variable_set('acquia_lift_decision_api_url', $decision_api_url);
+  variable_set('acquia_lift_oauth_url', $oauth_url);
+
+  // The rest of the variables are set as is.
+  $standard_variables = array(
+    'acquia_lift_identity_param',
+    'acquia_lift_identity_type_param',
+    'acquia_lift_default_identity_type',
+    'acquia_lift_account_id',
+    'acquia_lift_site_id',
+    'acquia_lift_ignore_path_patterns',
+    'acquia_lift_content_replacement_mode',
+  );
+  foreach ($standard_variables as $key) {
+    variable_set($key, $form_state['values'][$key]);
+  }
+
+  drupal_set_message(t('The configuration settings have been saved.'), 'status');
+}
+
+/**
+ * Clean up URL. Remove the:
+ *   1) Protocol "http://" and "http://".
+ *   2) Leading and trailing slashes and space characters.
+ *
+ * @param string $url
+ *   URL.
+ * @return string
+ *   URL, but cleaned up.
+ */
+function _acquia_lift_admin_clean_url($url) {
+  $searchFor = [
+    '~^[ \t\r\n\/]+~',
+    '~[ \t\r\n\/]+$~',
+    '~^https?://~',
+  ];
+  return preg_replace($searchFor, '', $url);
+}
+
+/**
+ * Remove the "/authorize" suffix, if any.
+ *
+ * @param string $url
+ *   URL.
+ * @return string
+ *   URL, but with "/authorize" removed.
+ */
+function _acquia_lift_admin_remove_authorize_suffix($url) {
+  return preg_replace('~/authorize$~', '', $url);
+}
+
+/**
+ * Pings a url and validates that the URL can be reached and shows messaging
+ * if it cannot..
+ * NOTE: the drupal 8 version of this functionality also checks the response
+ * code (expecting 200) but this does not seem possible as responses here
+ * are correctly 403, 400, etc.
+ *
+ * @param string $type
+ *   The type of the URL to check
+ * @param string $url
+ *   The URL to check
+ * @return bool
+ *   True if reachable, false otherwise.
+ */
+function _acquia_lift_ping($type, $url) {
+  $ch = curl_init($url);
+  curl_setopt($ch, CURLOPT_TIMEOUT, 5);
+  curl_setopt($ch, CURLOPT_NOBODY, TRUE);
+  curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+  curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+  curl_exec($ch);
+  $status_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+  curl_close($ch);
+  if ($status_code == 0) {
+    drupal_set_message(t('Acquia Lift module could not reach the specified @type URL.', array(
+      '@type' => $type,
+    )), 'error');
+    return FALSE;
+  }
+  return TRUE;
+}

--- a/acquia_lift.admin.inc
+++ b/acquia_lift.admin.inc
@@ -196,6 +196,11 @@ function _acquia_lift_admin_build_identity_form(&$form, &$form_state) {
       '@default_identity_type_display_value' => $default_identity_type_display_value,
     ]),
     '#default_value' => variable_get('acquia_lift_default_identity_type'),
+    '#states' => array(
+      'visible' => array(
+        ':input[name="acquia_lift_identity_param"]' => ['!value' => ''],
+      ),
+    ),
     '#placeholder' => ACQUIA_LIFT_DEFAULT_IDENTITY_TYPE_DEFAULT,
   );
 }

--- a/acquia_lift.admin.inc
+++ b/acquia_lift.admin.inc
@@ -159,14 +159,14 @@ function _acquia_lift_admin_build_credential_form(&$form, &$form_state) {
  */
 function _acquia_lift_admin_build_identity_form(&$form, &$form_state) {
   $identity_parameter_display_value = variable_get('acquia_lift_identity_param', 'identity');
-  $identity_type_parameter_display_value = variable_get('acquia_lift_identity_type_param', 'identityType');
-  $default_identity_type_display_value = variable_get('acquia_lift_default_identity_type', ACQUIA_LIFT_DEFAULT_IDENTITY_TYPE_IDENTIFIER);
-  $default_identity_type_default_value = variable_get('acquia_lift_default_identity_type', ACQUIA_LIFT_DEFAULT_IDENTITY_TYPE_DEFAULT);
+  $identity_type_parameter_display_value = variable_get('acquia_lift_identity_type_param') ?: 'identityType';
+  $default_identity_type_display_value = variable_get('acquia_lift_default_identity_type') ?: ACQUIA_LIFT_DEFAULT_IDENTITY_TYPE_IDENTIFIER;
+  $default_identity_type_default_value = variable_get('acquia_lift_default_identity_type') ?: ACQUIA_LIFT_DEFAULT_IDENTITY_TYPE_DEFAULT;
 
   $form['acquia_lift_identity_param'] = array(
     '#type' => 'textfield',
     '#title' => t('Identity Parameter'),
-    '#description' => t('The query string parameter for specific visitor information, such as an email address or social media username, which is sent to the Acquia Lift service. Example: ?<ins>@identity_parameter_display_value</ins>=jdoe01', [
+    '#description' => t('The URL link parameter for specific visitor information, such as an email address or social media username, which is sent to the Lift Profile Manager. Example using <strong>@identity_parameter_display_value</strong>: ?<strong><ins>@identity_parameter_display_value</ins></strong>=jdoe01', [
       '@identity_parameter_display_value' => $identity_parameter_display_value,
     ]),
     '#default_value' => variable_get('acquia_lift_identity_param'),
@@ -174,7 +174,7 @@ function _acquia_lift_admin_build_identity_form(&$form, &$form_state) {
   $form['acquia_lift_identity_type_param'] = array(
     '#type' => 'textfield',
     '#title' => t('Identity Type Parameter'),
-    '#description' => t('The query string parameter for the category (standard or custom) of the visitor\'s identity information. Example: ?@identity_parameter_display_value=jdoe01&<ins>@identity_type_parameter_display_value</ins>=@default_identity_type_default_value', [
+    '#description' => t('The URL link parameter that corresponds to a Lift Profile Manager identifier type (one of the pre-defined ones or a new one you\'ve created). Example using <strong>@identity_type_parameter_display_value</strong>: ?@identity_parameter_display_value=jdoe01&<strong><ins>@identity_type_parameter_display_value</ins></strong>=@default_identity_type_default_value', [
       '@identity_parameter_display_value' => $identity_parameter_display_value,
       '@identity_type_parameter_display_value' => $identity_type_parameter_display_value,
       '@default_identity_type_default_value' => $default_identity_type_default_value,
@@ -189,7 +189,7 @@ function _acquia_lift_admin_build_identity_form(&$form, &$form_state) {
   $form['acquia_lift_default_identity_type'] = array(
     '#type' => 'textfield',
     '#title' => t('Default Identity Type'),
-    '#description' => t('The identity type category to use by default. Leave this field blank to default to <ins>@default</ins>. Example: <ins>@default_identity_type_display_value</ins> is "?@identity_parameter_display_value=jdoe01&@identity_type_parameter_display_value=<ins>@default_identity_type_display_value</ins>", while blank is the same as "?@identity_parameter_display_value=jdoe01&@identity_type_parameter_display_value=<ins>@default</ins>"', [
+    '#description' => t('The Lift Profile Manager identity type to be used by default. Example using <strong>@default_identity_type_display_value</strong>: a visitor may visit the site through ?@identity_parameter_display_value=jdoe01 and omit the "@identity_type_parameter_display_value" query, and Lift will automatically identify this visitor as "jdoe01" of <strong><ins>@default_identity_type_display_value</ins></strong> type. Leave this field blank to default to <strong>@default</strong> identity type."', [
       '@default' => 'email',
       '@identity_parameter_display_value' => $identity_parameter_display_value,
       '@identity_type_parameter_display_value' => $identity_type_parameter_display_value,

--- a/acquia_lift.admin.inc
+++ b/acquia_lift.admin.inc
@@ -201,7 +201,9 @@ function _acquia_lift_admin_build_identity_form(&$form, &$form_state) {
         ':input[name="acquia_lift_identity_param"]' => ['!value' => ''],
       ),
     ),
-    '#placeholder' => ACQUIA_LIFT_DEFAULT_IDENTITY_TYPE_DEFAULT,
+    '#attributes' => array(
+      'placeholder' => ACQUIA_LIFT_DEFAULT_IDENTITY_TYPE_DEFAULT,
+    ),
   );
 }
 

--- a/acquia_lift.admin.inc
+++ b/acquia_lift.admin.inc
@@ -246,7 +246,7 @@ function _acquia_lift_admin_build_visibility_form(&$form, &$form_state) {
   $form['acquia_lift_ignore_path_patterns'] = array(
     '#type' => 'textarea',
     '#title' => t('Path patterns'),
-    '#default_value' => variable_get('acquia_lift_ignore_path_patterns', "/admin\n/admin/*\n/batch\n/node/add*\n/node/*/*\n/user/*/*\n/block/*"),
+    '#default_value' => variable_get('acquia_lift_ignore_path_patterns', "/admin\n/admin/*\n/batch\n/node/add*\n/node/*/*\n/user/*\n/block/*"),
   );
 }
 

--- a/acquia_lift.context.inc
+++ b/acquia_lift.context.inc
@@ -1,0 +1,156 @@
+<?php
+
+/**
+ * @file acquia_lift.context.inc
+ * Provides functions needed for handling visitor contexts.
+ */
+
+/**
+ * Gets all options for mappable contexts
+ *
+ * @return array
+ *   An array of options keyed by the context type
+ */
+function _acquia_lift_get_context_options() {
+  $contexts = array(
+    'taxonomy_context' => _acquia_lift_get_taxonomy_context_options(),
+  );
+  return array_filter($contexts);
+}
+
+/**
+ * Gets all the callbacks for finding the mapped value of a context type.
+ * The callback receives the the node and the mapped value.
+ *
+ * @return array
+ *   An array of callables.
+ */
+function _acquia_lift_get_mapping_callbacks() {
+  return array(
+    'taxonomy_context' => '_acquia_lift_get_mapped_taxonomy_context'
+  );
+}
+
+/**
+ * Gets all of the node fields that include taxonomy terms.
+ *
+ * @return array
+ *   An array of contextual options that can be used for grouped output.
+ */
+function _acquia_lift_get_taxonomy_context_options() {
+  if (!module_exists('taxonomy')) {
+    return array();
+  }
+
+  $vocabularies = taxonomy_get_vocabularies();
+  $options = array();
+  foreach ($vocabularies as $vocabulary) {
+    $machine_name = $vocabulary->machine_name;
+    $options[$machine_name] = array(
+      'name' => $vocabulary->name,
+      'machine_name' => $vocabulary->machine_name,
+      'group' => 'Taxonomy',
+      'id' => $vocabulary->vid,
+    );
+  }
+  return $options;
+}
+
+/**
+ * Handles the page context request data.
+ *
+ * @param $node
+ *   (optional) If passed then the taxonomy terms for the selected node
+ *   are added to the page taxonomy context.
+ * @param bool $primary
+ *   True if this is the primary node displayed for the page, false otherwise.
+ * @return array
+ *   Returns the taxonomy context for the page.
+ */
+function _acquia_lift_get_page_context($node = NULL, $primary = FALSE) {
+  $page_context = &drupal_static(__FUNCTION__);
+  if (!isset($page_context)) {
+    $page_context = array();
+  }
+
+  // Add the content type of the page if this is the primary node displayed.
+  if ($primary && empty($page_context['post_id'])) {
+    $page_context['content_type'] = $node->type;
+    $page_context['content_title'] = $node->title;
+    $page_context['published_date'] = $node->created;
+    $page_context['post_id'] = $node->nid;
+    $account = user_load($node->uid);
+    $page_context['author'] = $account->name;
+    $page_context['page_type'] = 'node page';
+    $page_context['type'] = $node->type;
+    $page_context = array_merge_recursive($page_context, _acquia_lift_get_mapped_context($node));
+  }
+
+  return $page_context;
+}
+
+/**
+ * Gets the mapped context for the current node including field mappings and
+ * udf mappings.
+ *
+ * @param $node
+ *   The node currently be displayed
+ * @return array
+ *   An array of contexts to be included with the page context.
+ */
+function _acquia_lift_get_mapped_context($node) {
+  $mapped_context = array();
+  $mapping_callbacks = _acquia_lift_get_mapping_callbacks();
+  // Field Mappings include content section, keywords, persona, etc.
+  $field_mappings = variable_get('acquia_lift_field_mappings', array());
+  foreach($field_mappings as $type => $mapping) {
+    list($context_type, $context) = explode(ACQUIA_LIFT_ADMIN_SEPARATOR, $mapping);
+    if (!array_key_exists($context_type, $mapping_callbacks)) {
+      continue;
+    }
+    $mapped_value = call_user_func($mapping_callbacks[$context_type], $node, $context);
+    if (!is_null($mapped_value)) {
+      $mapped_context[$type] = $mapped_value;
+    }
+  }
+  // UDF Mappings include keys for person, touch, event, etc.
+  $udf_mappings = variable_get('acquia_lift_udf_mappings', array());
+  foreach($udf_mappings as $type => $mapping) {
+    foreach($mapping as $udf => $mapping_context) {
+      list ($context_type, $context) = explode(ACQUIA_LIFT_ADMIN_SEPARATOR, $mapping_context);
+      if (!array_key_exists($context_type, $mapping_callbacks)) {
+        continue;
+      }
+      $mapped_value = call_user_func($mapping_callbacks[$context_type], $node, $context);
+      if (!is_null($mapped_value)) {
+        $mapped_context[$udf] = $mapped_value;
+      }
+    }
+  }
+  return $mapped_context;
+}
+
+/**
+ * Gets the list of taxonomy terms applied for a particular node and a
+ * particular taxonomy vocabulary.
+ * @param $node
+ *   The node that is being displayed
+ * @param string $vocabulary_machine_name
+ *   The machine name of the vocabulary
+ * @return null if no mapping, a string of terms if mapping exists.
+ */
+function _acquia_lift_get_mapped_taxonomy_context($node, $vocabulary_machine_name) {
+  if (empty($node) || empty($vocabulary_machine_name)) {
+    return null;
+  }
+  $mapped = array();
+  $results = db_query('SELECT tid FROM {taxonomy_index} WHERE nid = :nid', array(':nid' => $node->nid));
+  $terms = taxonomy_term_load_multiple($results->fetchCol());
+  foreach($terms as $term) {
+    if ($term->vocabulary_machine_name !== $vocabulary_machine_name) {
+      continue;
+    }
+    $mapped[] = $term->name;
+  }
+  return implode(',', $mapped);
+}

--- a/acquia_lift.context.inc
+++ b/acquia_lift.context.inc
@@ -82,7 +82,6 @@ function _acquia_lift_get_page_context($node = NULL, $primary = FALSE) {
     $account = user_load($node->uid);
     $page_context['author'] = $account->name;
     $page_context['page_type'] = 'node page';
-    $page_context['type'] = $node->type;
     $page_context = array_merge_recursive($page_context, _acquia_lift_get_mapped_context($node));
   }
 

--- a/acquia_lift.info
+++ b/acquia_lift.info
@@ -6,4 +6,3 @@ package = Acquia
 core = 7.x
 
 files[] = tests/acquia_lift.test
-files[] = tests/acquia_lift_unit.test

--- a/acquia_lift.info
+++ b/acquia_lift.info
@@ -1,0 +1,9 @@
+name = Acquia Lift
+description = Provides integration to the Acquia Lift service for personalization and visitor data collection.
+configure = admin/config/services/acquia_lift
+
+package = Acquia
+core = 7.x
+
+files[] = tests/acquia_lift.test
+files[] = tests/acquia_lift_unit.test

--- a/acquia_lift.install
+++ b/acquia_lift.install
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @file Acquia Lift - Installation file.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function acquia_lift_uninstall() {
+  $vars = array(
+    'acquia_lift_identity_param',
+    'acquia_lift_identity_type_param',
+    'acquia_lift_default_identity_type',
+    'acquia_lift_field_mappings',
+    'acquia_lift_udf_mappings',
+    'acquia_lift_account_id',
+    'acquia_lift_site_id',
+    'acquia_lift_assets_url',
+    'acquia_lift_decision_api_url',
+    'acquia_lift_oauth_url',
+    'acquia_lift_ignore_path_patterns',
+    'acquia_lift_content_replacement_mode',
+  );
+  foreach ($vars as $var) {
+    variable_del($var);
+  }
+}

--- a/acquia_lift.module
+++ b/acquia_lift.module
@@ -120,7 +120,7 @@ function acquia_lift_page_build(&$page) {
       // Set the identity type to the default either as specified by the user or
       // as the application default.
       $identity_type = variable_get('acquia_lift_default_identity_type') ?: ACQUIA_LIFT_DEFAULT_IDENTITY_TYPE_DEFAULT;
-      if (!empty($identity_type_param) && isset($all_params[$identity_type_param])) {
+      if (!empty($identity_type_param) && !empty($all_params[$identity_type_param])) {
         // If an explicit identity type was passed in the query parameters then
         //use that instead.
         $identity_type = check_plain($all_params[$identity_type_param]);

--- a/acquia_lift.module
+++ b/acquia_lift.module
@@ -1,0 +1,262 @@
+<?php
+
+/**
+ * @file acquia_lift.module
+ * Provides Acquia Lift Profiles integration.
+ */
+
+define('ACQUIA_LIFT_THUMBNAIL_WIDGET_SEPARATOR', '|');
+define('ACQUIA_LIFT_DEFAULT_IDENTITY_TYPE_DEFAULT', 'email');
+define('ACQUIA_LIFT_DEFAULT_IDENTITY_TYPE_IDENTIFIER', 'account');
+define('ACQUIA_LIFT_ENGAGEMENT_SCORE_DEFAULT', 1);
+define('ACQUIA_LIFT_GLOBAL_VALUE_DEFAULT', 1);
+define('ACQUIA_LIFT_ADMIN_SEPARATOR', '__');
+
+/**
+ * Implements hook_menu().
+ */
+function acquia_lift_menu() {
+  $items = array();
+  $items['admin/config/services/acquia_lift'] = array(
+    'type' => MENU_NORMAL_ITEM,
+    'title' => 'Acquia Lift',
+    'description' => 'Configuration settings for the Acquia Lift integration module.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('acquia_lift_admin_form'),
+    'access arguments' => array('administer acquia_lift configuration'),
+    'file' => 'acquia_lift.admin.inc'
+  );
+  return $items;
+}
+
+/**
+ * Implements hook_permission().
+ */
+function acquia_lift_permission() {
+  $permissions = array(
+    'administer acquia_lift configuration' => array(
+      'title' => t('Administer acquia_lift settings'),
+      'description' => t('Administer configuration settings for Acquia Lift.'),
+    ),
+  );
+  return $permissions;
+}
+
+/**
+ * Implements hook_help().
+ */
+function acquia_lift_help($path, $arg) {
+  switch ($path) {
+    case 'admin/help#acquia_lift':
+      $output = '<h3>' . t('About') . '</h3>';
+      $output .= '<p>' . t('The Acquia Lift module provides machine-learning-based personalization for Drupal sites.') . '</p>';
+      $output .= '<h3>' . t('Configuration') . '</h3>';
+      $output .= '<p>' . t('Go to the !configlink to configure your Acquia Lift credentials.', array('!configlink' => l(t('configuration settings page'), 'admin/config/services/acquia_lift'))) . '</p>';
+      $output .= '<p>' . t('You can find more info in <a href="@lift-documentation" target="_blank">Documentation</a>.', array(
+          '@lift-documentation' => 'https://docs.acquia.com/lift'
+        ));
+      return $output;
+  }
+}
+
+/**
+ * Returns whether or not Acquia Lift has been configured.
+ *
+ * @return bool
+ *   TRUE if all relevant configuration settings have been set, FALSE
+ *   otherwise.
+ */
+function acquia_lift_is_configured() {
+  foreach (array('acquia_lift_account_id','acquia_lift_site_id', 'acquia_lift_assets_url') as $api_config) {
+    $val = variable_get($api_config, '');
+    if (empty($val)) {
+      return FALSE;
+    }
+  }
+  return TRUE;
+}
+
+/**
+ * Implements hook_page_build().
+ */
+function acquia_lift_page_build(&$page) {
+  // Bail if Acquia Lift has not yet been configured.
+  if (!acquia_lift_is_configured()) {
+    return;
+  }
+
+  // Bail if the path is a path to ignore
+  $current_path = '/' . current_path();
+  $alias_path = drupal_lookup_path('alias', current_path());
+  $alias_path = $alias_path == FALSE ? $current_path : '/' . $alias_path;
+  $patterns = variable_get('acquia_lift_ignore_path_patterns', '');
+  if (drupal_match_path($current_path, $patterns) || drupal_match_path($alias_path, $patterns)) {
+    return;
+  }
+
+  $assets_url = variable_get('acquia_lift_assets_url');
+  $decision_api_url = variable_get('acquia_lift_decision_api_url', '');
+  $oauth_url = variable_get('acquia_lift_oauth_url', '');
+
+  // Add the credentials and configuration for the Lift Experience Builder.
+  _acquia_lift_add_meta_tag('account_id', variable_get('acquia_lift_account_id'));
+  _acquia_lift_add_meta_tag('site_id', variable_get('acquia_lift_site_id'));
+  _acquia_lift_add_meta_tag('liftAssetsUrl', $assets_url);
+  if (!empty($decision_api_url)) {
+    _acquia_lift_add_meta_tag('liftDecisionAPIURL', variable_get('acquia_lift_decision_api_url'));
+  }
+  if (!empty($oauth_url)) {
+    _acquia_lift_add_meta_tag('authEndpoint', variable_get('acquia_lift_oauth_url'));
+  }
+  _acquia_lift_add_meta_tag('contentReplacementMode', variable_get('acquia_lift_content_replacement_mode', 'untrusted'));
+
+  // If there are querystring parameters present corresponding to the configured
+  // identity params, we add the identity and identity type to the meta tags.
+  $identity_param = variable_get('acquia_lift_identity_param', '');
+  $identity_type_param = variable_get('acquia_lift_identity_type_param', '');
+  if (!empty($identity_param)) {
+    $all_params = drupal_get_query_parameters();
+    if (isset($all_params[$identity_param])) {
+      // Set the identity type to the default either as specified by the user or
+      // as the application default.
+      $identity_type = variable_get('acquia_lift_default_identity_type') ?: ACQUIA_LIFT_DEFAULT_IDENTITY_TYPE_DEFAULT;
+      if (!empty($identity_type_param) && isset($all_params[$identity_type_param])) {
+        // If an explicit identity type was passed in the query parameters then
+        //use that instead.
+        $identity_type = check_plain($all_params[$identity_type_param]);
+      }
+      $identity_value = check_plain($all_params[$identity_param]);
+      _acquia_lift_add_meta_tag('identity:' . $identity_type, $identity_value);
+    }
+  }
+
+  $page_context = acquia_lift_get_page_context();
+  foreach ($page_context as $name => $value) {
+    _acquia_lift_add_meta_tag($name, is_array($value) ? implode(',', $value) : $value);
+  }
+
+  // Add the lift js bootstrap loader
+  $js_file = $assets_url . '/lift.js';
+  $attached['js'] = array(
+    'type' => 'file',
+    'file' => $js_file,
+    'weight' => JS_DEFAULT - 10,
+  );
+  $page['page_top']['acquia_lift'] = array(
+    '#attached' => $attached
+  );
+}
+
+/**
+ * Implements hook_node_view().
+ */
+function acquia_lift_node_view($node, $view_mode, $langcode) {
+  acquia_lift_get_page_context($node, $view_mode == 'full');
+}
+
+/**
+ * Implements hook_ctools_render_alter().
+ *
+ * This provides support for panelizer nodes, which don't fire hook_view_alter.
+ */
+function acquia_lift_ctools_render_alter(&$info, &$page, &$context) {
+  $task = $context['task'];
+  if ($page && $task['module'] == 'page_manager' && $task['name'] == 'node_view' && !empty($context['args'])) {
+    $nid = $context['args'][0];
+    if (isset($context['contexts']['argument_entity_id:node_1']) && $context['contexts']['argument_entity_id:node_1']->argument == $nid) {
+      $node = $context['contexts']['argument_entity_id:node_1']->data;
+      acquia_lift_get_page_context($node, TRUE);
+    }
+  }
+}
+
+/**
+ * Gets the page context data.
+ *
+ * @return
+ *   An array of page context data.
+ */
+function acquia_lift_get_page_context($node = NULL, $primary = FALSE) {
+  // Add any page context
+  module_load_include('inc', 'acquia_lift', 'acquia_lift.context');
+  $page_context = _acquia_lift_get_page_context($node, $primary);
+
+  if (!isset($page_context['content_title']) && is_null($node)) {
+    $page_context['content_title'] = drupal_get_title();
+  }
+
+  // Allow other modules to alter the page context to include additional data.
+  drupal_alter('acquia_lift_page_context', $page_context);
+  return $page_context;
+}
+
+/**
+ * Helper function to return a list of udf types.
+ *
+ * @return array
+ *   An array of UDF types defined in Acquia Lift Profile Manager with keys
+ *   as the type name and values as the number allowed.
+ */
+function acquia_lift_get_udf_types() {
+  return array(
+    'person' => 50,
+    'touch' => 20,
+    'event' => 20,
+  );
+}
+
+/**
+ * Returns the list of UDFs that can be mapped to.
+ *
+ * @param string $type
+ *   The type of udf to generate, one of: touch, person, event
+ *
+ * @return array
+ *   An array of UDFs defined in Acquia Lift Profile Manager.
+ */
+function acquia_lift_get_udfs($type) {
+  $counts = acquia_lift_get_udf_types();
+  if (!array_key_exists($type, $counts)) {
+    return array();
+  }
+  $count = $counts[$type];
+
+  for ($i = 1; $i <= $count; $i++) {
+    $udfs[] = $type . '_udf' . $i;
+  }
+  return $udfs;
+}
+
+function acquia_lift_get_grouped_context_options() {
+  module_load_include('inc', 'acquia_lift', 'acquia_lift.context');
+  $context_options = _acquia_lift_get_context_options();
+  foreach ($context_options as $context_type => $options) {
+    foreach ($options as $code => $info) {
+      $option_name = $context_type . ACQUIA_LIFT_ADMIN_SEPARATOR . $code;
+      if (isset($info['group'])) {
+        $group = $info['group'];
+        if (!isset($groups[$group])) {
+          $groups[$group] = array();
+        }
+        $groups[$group][$option_name] = $info['name'];
+      }
+      else {
+        $groups['Miscellaneous'][$option_name] = $info['name'];
+      }
+    }
+  }
+  return $groups;
+}
+
+function _acquia_lift_add_meta_tag($name, $value) {
+  $tag = array(
+    '#type' => 'html_tag',
+    '#tag' => 'meta',
+    '#attributes' => array(
+      'content' =>  $value,
+      'itemprop' => 'acquia_lift:' . $name,
+    )
+  );
+  drupal_add_html_head($tag, 'acquia_lift_' . $name);
+}
+

--- a/acquia_lift.module
+++ b/acquia_lift.module
@@ -20,7 +20,7 @@ function acquia_lift_menu() {
   $items['admin/config/services/acquia_lift'] = array(
     'type' => MENU_NORMAL_ITEM,
     'title' => 'Acquia Lift',
-    'description' => 'Configuration settings for the Acquia Lift integration module.',
+    'description' => 'Configure Acquia Lift settings',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('acquia_lift_admin_form'),
     'access arguments' => array('administer acquia_lift configuration'),

--- a/acquia_lift.module
+++ b/acquia_lift.module
@@ -253,8 +253,8 @@ function _acquia_lift_add_meta_tag($name, $value) {
     '#type' => 'html_tag',
     '#tag' => 'meta',
     '#attributes' => array(
-      'content' =>  $value,
       'itemprop' => 'acquia_lift:' . $name,
+      'content' =>  $value,
     )
   );
   drupal_add_html_head($tag, 'acquia_lift_' . $name);

--- a/acquia_lift.module
+++ b/acquia_lift.module
@@ -201,7 +201,7 @@ function acquia_lift_get_udf_types() {
   return array(
     'person' => 50,
     'touch' => 20,
-    'event' => 20,
+    'event' => 50,
   );
 }
 

--- a/tests/acquia_lift.test
+++ b/tests/acquia_lift.test
@@ -92,9 +92,9 @@ class AcquiaLiftsWebTest extends DrupalWebTestCase {
     );
     for ($i = 1; $i <= 50; $i++) {
       $fields[] = 'acquia_lift_udf_mappings[person][person_udf' . $i . ']';
+      $fields[] = 'acquia_lift_udf_mappings[event][event_udf' . $i . ']';
     }
     for ($i = 1; $i <= 20; $i++) {
-      $fields[] = 'acquia_lift_udf_mappings[event][event_udf' . $i . ']';
       $fields[] = 'acquia_lift_udf_mappings[touch][touch_udf' . $i . ']';
     }
 

--- a/tests/acquia_lift.test
+++ b/tests/acquia_lift.test
@@ -10,8 +10,8 @@
  */
 class AcquiaLiftsWebTest extends DrupalWebTestCase {
 
-  protected $admin_user;
-  protected $admin_button_text;
+  private $admin_user;
+  private $admin_button_text;
 
   public static function getInfo() {
     return array(
@@ -438,7 +438,7 @@ class AcquiaLiftsWebTest extends DrupalWebTestCase {
   /**
    * Helper function to configure acquia_lift settings.
    */
-  protected function configureLift() {
+  private function configureLift() {
     $settings = array(
       'acquia_lift_account_id' => 'MY_ACCOUNT_ID',
       'acquia_lift_site_id' => 'MY_SITE_ID',
@@ -452,21 +452,21 @@ class AcquiaLiftsWebTest extends DrupalWebTestCase {
   /**
    * Helper function to assert that Lift is available on the page
    */
-  protected function assertLift() {
+  private function assertLift() {
     $this->assertRaw($this->getLiftBootstrapUrl(), 'Lift bootstrap is included on the page.');
   }
 
   /**
    * Helper function to assert that Lift is not available on the page
    */
-  protected function assertNoLift() {
+  private function assertNoLift() {
     $this->assertNoRaw($this->getLiftBootstrapUrl(), 'Lift bootstrap is not included on the page.');
   }
 
   /**
    * Helper function to assert that a meta tag is found in the page
    */
-  protected function assertLiftMetaTag($name, $value = NULL) {
+  private function assertLiftMetaTag($name, $value = NULL) {
     $pattern = '/<meta (?=[^>]*itemprop="acquia_lift:' . preg_quote($name, '/') . '")';
     if (!empty($value)) {
       $pattern .= '(?=[^>]*content="' . preg_quote($value, '/') . '")';
@@ -478,7 +478,7 @@ class AcquiaLiftsWebTest extends DrupalWebTestCase {
   /**
    * Helper function to assert that a meta tag is not found in the page
    */
-  protected function assertNoLiftMetaTag($name) {
+  private function assertNoLiftMetaTag($name) {
     $pattern = '/<meta (?=[^>]*itemprop="acquia_lift:' . preg_quote($name, '/') . '")/';
     $this->assertNoPattern($pattern, 'Did not find meta tag for ' . $name);
   }
@@ -486,7 +486,7 @@ class AcquiaLiftsWebTest extends DrupalWebTestCase {
   /**
    * Helper function to assert that an identifier  meta tag is found in the page
    */
-  protected function assertLiftIdentityMetaTag($type = NULL, $value = NULL) {
+  private function assertLiftIdentityMetaTag($type = NULL, $value = NULL) {
     if ($type) {
       $pattern = '/<meta (?=[^>]*itemprop="acquia_lift:identity:' . preg_quote($type, '/') . '")';
       if (!empty($value)) {
@@ -503,7 +503,7 @@ class AcquiaLiftsWebTest extends DrupalWebTestCase {
   /**
    * Helper function to assert that a meta tag is not found in the page
    */
-  protected function assertNoLiftIdentityMetaTag($name = NULL) {
+  private function assertNoLiftIdentityMetaTag($name = NULL) {
     $pattern = '/<meta (?=[^>]*itemprop="acquia_lift:identity';
     if ($name) {
       $pattern .= preg_quote($name, '/');
@@ -515,7 +515,7 @@ class AcquiaLiftsWebTest extends DrupalWebTestCase {
   /**
    * Helper function to generate the lift bootstrap URL.
    */
-  protected function getLiftBootstrapUrl() {
+  private function getLiftBootstrapUrl() {
     $assets_url = variable_get('acquia_lift_assets_url', '');
     return $assets_url . '/lift.js';
   }
@@ -531,7 +531,7 @@ class AcquiaLiftsWebTest extends DrupalWebTestCase {
    * @return object
    *   The node object.
    */
-  function createArticleWithTerms($autocreate = array(), $existing = array()) {
+  private function createArticleWithTerms($autocreate = array(), $existing = array()) {
     $values = array();
     foreach ($autocreate as $name) {
       $values[] = array(

--- a/tests/acquia_lift.test
+++ b/tests/acquia_lift.test
@@ -1,0 +1,561 @@
+<?php
+
+/**
+ * @file
+ * Tests for Acquia Lift Profiles module.
+ */
+
+/**
+ * Tests Acquia Lift functionality.
+ */
+class AcquiaLiftsWebTest extends DrupalWebTestCase {
+
+  protected $admin_user;
+  protected $admin_button_text;
+
+  public static function getInfo() {
+    return array(
+      'name' => t('Acquia Lift Tests'),
+      'description' => t('Tests basic functionality of Acquia Lift module.'),
+      'group' => t('Acquia'),
+    );
+  }
+
+  function setUp() {
+    parent::setUp(array('acquia_lift'));
+    $this->admin_button_text = t('Save configuration');
+    $this->admin_user = $this->drupalCreateUser(array(
+      'access administration pages',
+      'administer acquia_lift configuration',
+      'administer content types',
+      'administer nodes',
+      'bypass node access'
+    ));
+
+    // Set up a variety of nodes with different term combinations.
+    $this->tags['one_tag'] = array($this->randomName());
+    $this->tags['two_tags'] = array($this->randomName(), $this->randomName());
+    $this->articles['one_tag'] =
+      $this->createArticleWithTerms($this->tags['one_tag']);
+    $this->articles['two_tags'] =
+      $this->createArticleWithTerms($this->tags['two_tags']);
+  }
+
+  function tearDown() {
+    $vars = array(
+      'acquia_lift_identity_param',
+      'acquia_lift_identity_type_param',
+      'acquia_lift_default_identity_type',
+      'acquia_lift_field_mappings',
+      'acquia_lift_udf_mappings',
+      'acquia_lift_identity_param',
+      'acquia_lift_identity_type_param',
+      'acquia_lift_account_id',
+      'acquia_lift_site_id',
+      'acquia_lift_assets_url',
+      'acquia_lift_decision_api_url',
+      'acquia_lift_oauth_url',
+      'acquia_lift_ignore_path_patterns',
+      'acquia_lift_content_replacement_mode',
+    );
+    foreach ($vars as $index => $name) {
+      variable_del($name);
+    }
+    parent::tearDown();
+  }
+
+  /**
+   * Tests the configuration form for Acquia Lift.
+   */
+  function testAdminSettingsForm() {
+    $this->drupalLogin($this->admin_user);
+    $this->drupalGet('/admin/config/services/acquia_lift');
+
+    $submit_confirm_text = t('The configuration settings have been saved.');
+    $submit_button_text = $this->admin_button_text;
+
+    // Confirm expected fields
+    $fields = array(
+      'acquia_lift_account_id',
+      'acquia_lift_site_id',
+      'acquia_lift_assets_url',
+      'acquia_lift_decision_api_url',
+      'acquia_lift_oauth_url',
+      'acquia_lift_identity_param',
+      'acquia_lift_identity_type_param',
+      'acquia_lift_default_identity_type',
+      'acquia_lift_ignore_path_patterns',
+      'acquia_lift_content_replacement_mode',
+      'acquia_lift_field_mappings[content_section]',
+      'acquia_lift_field_mappings[content_keywords]',
+      'acquia_lift_field_mappings[persona]',
+    );
+    for ($i = 1; $i <= 50; $i++) {
+      $fields[] = 'acquia_lift_udf_mappings[person][person_udf' . $i . ']';
+    }
+    for ($i = 1; $i <= 20; $i++) {
+      $fields[] = 'acquia_lift_udf_mappings[event][event_udf' . $i . ']';
+      $fields[] = 'acquia_lift_udf_mappings[touch][touch_udf' . $i . ']';
+    }
+
+    foreach($fields as $fieldname) {
+      $this->assertField($fieldname, 'Found field name: ' . $fieldname);
+    }
+
+    // Confirm required fields
+    $this->drupalPost(NULL, array(), $submit_button_text);
+    $this->assertText(t('Account ID field is required.'), 'Found error for required account id');
+    $this->assertText(t('Site ID field is required.'), 'Found error for required site id');
+    $this->assertText(t('Assets URL field is required.'), 'Found error for required assets url');
+    $this->assertNoText($submit_confirm_text, 'Confirmation text is not shown');
+
+    // Update minimum and confirm values set as variables
+    $edit = array(
+      'acquia_lift_account_id' => 'MY_ACCOUNT',
+      'acquia_lift_site_id' => 'MY_SITE',
+      'acquia_lift_assets_url' => 'example.com/latest',
+    );
+    $this->drupalPost(NULL, $edit, $submit_button_text);
+    $this->assertText($submit_confirm_text);
+    $this->assertEqual(variable_get('acquia_lift_account_id'), 'MY_ACCOUNT', 'Account ID was persisted.');
+    $this->assertEqual(variable_get('acquia_lift_site_id'), 'MY_SITE', 'Site ID was persisted.');
+    $this->assertEqual(variable_get('acquia_lift_assets_url'), 'https://example.com/latest', 'Assets URL was persisted.');
+
+    // Test visibility settings
+    $test_path_patterns = "/testing\n/testing/*";
+    $this->assertNotEqual(variable_get('acquia_lift_ignore_path_patterns'), $test_path_patterns, 'Path patterns are in initial state.');
+    $edit['acquia_lift_ignore_path_patterns'] = $test_path_patterns;
+    $this->drupalPost(NULL, $edit, $submit_button_text);
+    $this->assertText($submit_confirm_text);
+    $this->assertEqual(variable_get('acquia_lift_ignore_path_patterns'), $test_path_patterns, 'Visibility path patterns were updated.');
+
+    // Test content replacement mode settings
+    $this->assertEqual(variable_get('acquia_lift_content_replacement_mode'), 'untrusted', 'Content replacement initially saved in default untrusted mode.');
+    $edit['acquia_lift_content_replacement_mode'] = 'trusted';
+    $this->drupalPost(NULL, $edit, $submit_button_text);
+    $this->assertText($submit_confirm_text);
+    $this->assertEqual(variable_get('acquia_lift_content_replacement_mode'), 'trusted', 'Content replacement mode was updated to trusted.');
+
+    // Only UDF mappings will values should be stored.
+    $this->assertTrue(empty(variable_get('acquia_lift_udf_mappings')), 'UDF Mappings are initially empty.');
+    $edit['acquia_lift_udf_mappings[person][person_udf1]'] = 'taxonomy_context__tags';
+    $edit['acquia_lift_udf_mappings[event][event_udf3]'] = 'taxonomy_context__tags';
+    $edit['acquia_lift_udf_mappings[touch][touch_udf2]'] = 'taxonomy_context__tags';
+    $edit['acquia_lift_udf_mappings[touch][touch_udf10]'] = 'taxonomy_context__tags';
+    $this->drupalPost(NULL, $edit, $submit_button_text);
+    $this->assertText($submit_confirm_text);
+    $expected = array(
+      'person' => array(
+        'person_udf1' => 'taxonomy_context__tags',
+      ),
+      'event' => array(
+        'event_udf3' => 'taxonomy_context__tags',
+      ),
+      'touch' => array(
+        'touch_udf2' => 'taxonomy_context__tags',
+        'touch_udf10' => 'taxonomy_context__tags',
+      ),
+    );
+    $this->assertEqual(variable_get('acquia_lift_udf_mappings'), $expected, 'Only udfs set to values are saved.');
+
+    $edit['acquia_lift_udf_mappings[event][event_udf3]'] = '';
+    unset($expected['event']);
+    $this->drupalPost(NULL, $edit, $submit_button_text);
+    $this->assertText($submit_confirm_text);
+    $this->assertEqual(variable_get('acquia_lift_udf_mappings'), $expected, 'Only udfs types with values set are saved.');
+
+    // Confirm field mappings only store those with values.
+    $this->assertTrue(empty(variable_get('acquia_lift_field_mappings')), 'Field Mappings are initially empty.');
+    $edit['acquia_lift_field_mappings[content_section]'] = 'taxonomy_context__tags';
+    $edit['acquia_lift_field_mappings[content_keywords]'] = 'taxonomy_context__tags';
+    $edit['acquia_lift_field_mappings[persona]'] = 'taxonomy_context__tags';
+
+    $expected = array(
+      'content_section' => 'taxonomy_context__tags',
+      'content_keywords' => 'taxonomy_context__tags',
+      'persona' => 'taxonomy_context__tags',
+    );
+    $this->drupalPost(NULL, $edit, $submit_button_text);
+    $this->assertText($submit_confirm_text);
+    $this->assertEqual(variable_get('acquia_lift_field_mappings'), $expected, 'All field mappings fields are updateable as expected.');
+
+    $edit['acquia_lift_field_mappings[persona]'] = '';
+    unset($expected['persona']);
+    $this->drupalPost(NULL, $edit, $submit_button_text);
+    $this->assertText($submit_confirm_text);
+    $this->assertEqual(variable_get('acquia_lift_field_mappings'), $expected, 'Only field mappings that have values are stored.');
+
+    // Confirm account id validation
+    $invalid = array(
+      '1myid',
+      'account-id',
+      'Accoun#',
+    );
+    $valid = array(
+      'my_account',
+      'MYID',
+    );
+    foreach($invalid as $test_id) {
+      $edit['acquia_lift_account_id'] = $test_id;
+      $this->drupalPost(NULL, $edit, $submit_button_text);
+      $this->assertNoText($submit_confirm_text);
+      $this->assertText(t('Account ID contains invalid characters'));
+    }
+    foreach($valid as $test_id) {
+      $edit['acquia_lift_account_id'] = $test_id;
+      $this->drupalPost(NULL, $edit, $submit_button_text);
+      $this->assertText($submit_confirm_text);
+      $this->assertNoText(t('Account ID contains invalid characters'));
+    }
+
+    // Confirm url validation
+    $url_fields = array('acquia_lift_assets_url', 'acquia_lift_decision_api_url', 'acquia_lift_oauth_url');
+    $invalid_urls = array('test@%', '2^');
+    $valid_urls = array(
+      array(
+        'test' => 'http://www.example.com/',
+        'result' => 'https://www.example.com',
+      ),
+      array(
+        'test' => 'localhost',
+        'result' => 'https://localhost',
+      ),
+      array(
+        'test' => '/myurl',
+        'result' => 'https://myurl',
+      ),
+    );
+    foreach($url_fields as $test_field) {
+      foreach ($invalid_urls as $test) {
+        $edit[$test_field] = $test;
+        $this->drupalPost(NULL, $edit, $submit_button_text);
+        $this->assertNoText($submit_confirm_text);
+        $this->assertText(t('is an invalid URL'), $test . ' is an invalid url.');
+      }
+      foreach($valid_urls as $case) {
+        $expected_variable = $test_field == 'acquia_lift_oauth_url' ? $case['result'] . '/authorize' : $case['result'];
+        $edit[$test_field] = $case['test'];
+        $this->drupalPost(NULL, $edit, $submit_button_text);
+        $this->assertText($submit_confirm_text);
+        $this->assertNoText(t('is an invalid URL'), $case['test'] . ' is a valid url');
+        $this->assertEqual(variable_get($test_field), $expected_variable, $test_field . ' set to ' . $expected_variable);
+      }
+    }
+  }
+
+  /**
+   * Test the visibility path filtering.
+   */
+  function testVisibilityFiltering() {
+    $node = $this->drupalCreateNode();
+    $node_url = '/node/' . $node->nid;
+
+    // No lift when not configured.
+    $this->drupalGet($node_url);
+    $this->assertNoLift();
+
+    // Configured without limitations
+    $this->configureLift();
+    $this->drupalGet($node_url);
+    $this->assertLift();
+
+    // No node pages should have Lift
+    variable_set('acquia_lift_ignore_path_patterns', '/node/*');
+    $this->drupalGet($node_url);
+    $this->assertNoLift();
+
+    // Only the root node page should be restricted
+    variable_set('acquia_lift_ignore_path_patterns', '/node');
+    $this->drupalGet($node_url);
+    $this->assertLift();
+
+    // Multiple paths are restricted
+    variable_set('acquia_lift_ignore_path_patterns', "/node\n/node/*");
+    $this->drupalGet($node_url);
+    $this->assertNoLift();
+  }
+
+  /**
+   * Test credentials are output for Lift.
+   */
+  function testLiftCredentials() {
+    // Lift not configured then no credentials
+    $this->drupalGet('/');
+    $this->assertNoLift();
+    $this->assertNoLiftMetaTag('account_id');
+    $this->assertNoLiftMetaTag('site_id');
+    $this->assertNoLiftMetaTag('liftAssetsUrl');
+    $this->assertNoLiftMetaTag('liftDecisionAPIURL');
+    $this->assertNoLiftMetaTag('authEndpoint');
+    $this->assertNoLiftMetaTag('contentReplacementMode');
+
+    $this->configureLift();
+    // Sets up the account id, site id, and assets url.
+    $this->drupalGet('/');
+    $this->assertLift();
+    $this->assertLiftMetaTag('account_id');
+    $this->assertLiftMetaTag('site_id');
+    $this->assertLiftMetaTag('liftAssetsUrl');
+    $this->assertNoLiftMetaTag('liftDecisionAPIURL');
+    $this->assertNoLiftMetaTag('authEndpoint');
+    $this->assertLiftMetaTag('contentReplacementMode', 'untrusted');
+
+    // Manually set all the configuration variables and confirm meta tags.
+    variable_set('acquia_lift_account_id', 'MY_ACCOUNT');
+    variable_set('acquia_lift_site_id', 'MY_SITE');
+    variable_set('acquia_lift_assets_url', 'https://example.com/assets/stable');
+    variable_set('acquia_lift_decision_api_url', 'https://example.com/decisionapi');
+    variable_set('acquia_lift_oauth_url', 'https://example.com/authorize');
+    variable_set('acquia_lift_content_replacement_mode', 'trusted');
+
+    $this->drupalGet('/');
+    $this->assertLift();
+    $this->assertLiftMetaTag('account_id', 'MY_ACCOUNT');
+    $this->assertLiftMetaTag('site_id', 'MY_SITE');
+    $this->assertLiftMetaTag('liftAssetsUrl', 'https://example.com/assets/stable');
+    $this->assertLiftMetaTag('liftDecisionAPIURL', 'https://example.com/decisionapi');
+    $this->assertLiftMetaTag('authEndpoint', 'https://example.com/authorize');
+    $this->assertLiftMetaTag('contentReplacementMode', 'trusted');
+  }
+
+  /**
+   * Tests identity param configuration and js settings.
+   */
+  function testIdentityParams() {
+    $submit_button_text = $this->admin_button_text;
+    $this->configureLift();
+    $this->drupalLogin($this->admin_user);
+    // Test specifying a querystring param to use for capturing identity.
+    $this->drupalPost('/admin/config/services/acquia_lift', array(
+      'acquia_lift_identity_param' => 'ali',
+    ), $submit_button_text);
+    $this->drupalLogout();
+
+    // Now visit the site as anon without passing any querystring params.
+    $this->drupalGet('');
+    $this->assertNoLiftIdentityMetaTag();
+
+    // Now pass the configured identity param
+    $my_id = 'ohai';
+    $this->drupalGet('', array('query' => array('ali' => $my_id)));
+    $this->assertLiftIdentityMetaTag(ACQUIA_LIFT_DEFAULT_IDENTITY_TYPE_DEFAULT, $my_id);
+
+    // Set the identity type param
+    $this->drupalLogin($this->admin_user);
+    $this->drupalPost('admin/config/services/acquia_lift', array(
+      'acquia_lift_identity_type_param' => 'alit',
+    ), $submit_button_text);
+    $this->drupalLogout();
+
+    // Pass the configured identity param and the identity_type param
+    $my_type = 'socialtastic';
+    $this->drupalGet('', array('query' => array('ali' => $my_id, 'alit' => $my_type)));
+    $this->assertLiftIdentityMetaTag($my_type, $my_id);
+
+    // Pass the configured identity type param without the identity param
+    $this->drupalGet('', array('query' => array('alit' => $my_type)));
+    $this->assertNoLiftIdentityMetaTag();
+
+    // Set the default identity type
+    $default_type = 'tknr';
+    $this->drupalLogin($this->admin_user);
+    $this->drupalPost('admin/config/services/acquia_lift', array(
+      'acquia_lift_default_identity_type' => $default_type,
+    ), $submit_button_text);
+    $this->drupalLogout();
+
+    // Pass the configured identity param but without the identity_type param
+    $this->drupalGet('', array('query' => array('ali' => $my_id)));
+    $this->assertLiftIdentityMetaTag($default_type, $my_id);
+
+    // Pass the configured identity param and with the identity_type param
+    $this->drupalGet('', array('query' => array('ali' => $my_id, 'alit' => $my_type)));
+    $this->assertLiftIdentityMetaTag($my_type, $my_id);
+  }
+
+  function testFieldMappings() {
+    $submit_button_text = $this->admin_button_text;
+    $this->configureLift();
+    $this->drupalLogin($this->admin_user);
+
+    $edit = array(
+      'acquia_lift_field_mappings[content_section]' => 'taxonomy_context__tags',
+      'acquia_lift_field_mappings[content_keywords]' => 'taxonomy_context__tags',
+      'acquia_lift_field_mappings[persona]' => 'taxonomy_context__tags',
+    );
+    $this->drupalPost('admin/config/services/acquia_lift', $edit, $submit_button_text);
+    $this->drupalGet('node/' . $this->articles['one_tag']->nid);
+    $expected_tag = $this->tags['one_tag'][0];
+    $this->assertLiftMetaTag('content_section', $expected_tag);
+    $this->assertLiftMetaTag('content_keywords', $expected_tag);
+    $this->assertLiftMetaTag('persona', $expected_tag);
+
+    $this->drupalGet('node/' . $this->articles['two_tags']->nid);
+    $expected_tags = implode(',', $this->tags['two_tags']);
+    $this->assertLiftMetaTag('content_section', $expected_tags);
+    $this->assertLiftMetaTag('content_keywords', $expected_tags);
+    $this->assertLiftMetaTag('persona', $expected_tags);
+
+    $edit = array(
+      'acquia_lift_field_mappings[content_section]' => 'taxonomy_context__tags',
+      'acquia_lift_field_mappings[content_keywords]' => '',
+      'acquia_lift_field_mappings[persona]' => 'taxonomy_context__tags',
+    );
+    $this->drupalPost('admin/config/services/acquia_lift', $edit, $submit_button_text);
+    $this->drupalGet('node/' . $this->articles['one_tag']->nid);
+    $expected_tag = $this->tags['one_tag'][0];
+    $this->assertLiftMetaTag('content_section', $expected_tag);
+    $this->assertNoLiftMetaTag('content_keywords');
+    $this->assertLiftMetaTag('persona', $expected_tag);
+  }
+
+  function testUDFMappings() {
+    $this->configureLift();
+    $this->drupalLogin($this->admin_user);
+    $edit = array(
+      'acquia_lift_udf_mappings[person][person_udf1]' => 'taxonomy_context__tags',
+      'acquia_lift_udf_mappings[touch][touch_udf20]' => 'taxonomy_context__tags'
+    );
+    $this->drupalPost('admin/config/services/acquia_lift', $edit, $this->admin_button_text);
+    $this->drupalGet('node/' . $this->articles['one_tag']->nid);
+    $expected_tag = $this->tags['one_tag'][0];
+    $this->assertLiftMetaTag('person_udf1', $expected_tag);
+    $this->assertLiftMetaTag('touch_udf20', $expected_tag);
+
+    $edit = array(
+      'acquia_lift_udf_mappings[person][person_udf1]' => 'taxonomy_context__tags',
+      'acquia_lift_udf_mappings[touch][touch_udf20]' => '',
+      'acquia_lift_udf_mappings[event][event_udf5]' => 'taxonomy_context__tags',
+    );
+    $this->drupalPost('admin/config/services/acquia_lift', $edit, $this->admin_button_text);
+    $this->drupalGet('node/' . $this->articles['two_tags']->nid);
+    $expected_tags = implode(',', $this->tags['two_tags']);
+    $this->assertLiftMetaTag('person_udf1', $expected_tags);
+    $this->assertNoLiftMetaTag('touch_udf20');
+    $this->assertLiftMetaTag('event_udf5', $expected_tags);
+  }
+
+  /**
+   * Helper function to configure acquia_lift settings.
+   */
+  protected function configureLift() {
+    $settings = array(
+      'acquia_lift_account_id' => 'MY_ACCOUNT_ID',
+      'acquia_lift_site_id' => 'MY_SITE_ID',
+      'acquia_lift_assets_url' => 'https://example.com/latest',
+    );
+    foreach ($settings as $setting => $value) {
+      variable_set($setting, $value);
+    }
+  }
+
+  /**
+   * Helper function to assert that Lift is available on the page
+   */
+  protected function assertLift() {
+    $this->assertRaw($this->getLiftBootstrapUrl(), 'Lift bootstrap is included on the page.');
+  }
+
+  /**
+   * Helper function to assert that Lift is not available on the page
+   */
+  protected function assertNoLift() {
+    $this->assertNoRaw($this->getLiftBootstrapUrl(), 'Lift bootstrap is not included on the page.');
+  }
+
+  /**
+   * Helper function to assert that a meta tag is found in the page
+   */
+  protected function assertLiftMetaTag($name, $value = NULL) {
+    $pattern = '/<meta (?=[^>]*itemprop="acquia_lift:' . preg_quote($name, '/') . '")';
+    if (!empty($value)) {
+      $pattern .= '(?=[^>]*content="' . preg_quote($value, '/') . '")';
+    }
+    $pattern .= '/';
+    $this->assertPattern($pattern, 'Found meta tag for ' . $name);
+  }
+
+  /**
+   * Helper function to assert that a meta tag is not found in the page
+   */
+  protected function assertNoLiftMetaTag($name) {
+    $pattern = '/<meta (?=[^>]*itemprop="acquia_lift:' . preg_quote($name, '/') . '")/';
+    $this->assertNoPattern($pattern, 'Did not find meta tag for ' . $name);
+  }
+
+  /**
+   * Helper function to assert that an identifier  meta tag is found in the page
+   */
+  protected function assertLiftIdentityMetaTag($type = NULL, $value = NULL) {
+    if ($type) {
+      $pattern = '/<meta (?=[^>]*itemprop="acquia_lift:identity:' . preg_quote($type, '/') . '")';
+      if (!empty($value)) {
+        $pattern .= '(?=[^>]*content="' . preg_quote($value, '/') . '")';
+      }
+      $pattern .= '/';
+    }
+    else {
+      $pattern = '/<meta (?=[^>]*itemprop="acquia_lift:identity:)/';
+    }
+    $this->assertPattern($pattern, 'Found identity meta tag' . $type ? ' for ' . $type : '');
+  }
+
+  /**
+   * Helper function to assert that a meta tag is not found in the page
+   */
+  protected function assertNoLiftIdentityMetaTag($name = NULL) {
+    $pattern = '/<meta (?=[^>]*itemprop="acquia_lift:identity';
+    if ($name) {
+      $pattern .= preg_quote($name, '/');
+    }
+    $pattern .= ')/';
+    $this->assertNoPattern($pattern, 'Did not find meta tag for ' . $name);
+  }
+
+  /**
+   * Helper function to generate the lift bootstrap URL.
+   */
+  protected function getLiftBootstrapUrl() {
+    $assets_url = variable_get('acquia_lift_assets_url', '');
+    return $assets_url . '/lift.js';
+  }
+
+  /**
+   * Creates an article with the specified terms.
+   *
+   * @param array $autocreate
+   *   (optional) An array of term names to autocreate. Defaults to array().
+   * @param array $existing
+   *   (optional) An array of existing term IDs to add.
+   *
+   * @return object
+   *   The node object.
+   */
+  function createArticleWithTerms($autocreate = array(), $existing = array()) {
+    $values = array();
+    foreach ($autocreate as $name) {
+      $values[] = array(
+        'tid' => 'autocreate',
+        'vid' => 1,
+        'name' => $name,
+        'vocabulary_machine_name' => 'tags'
+      );
+    }
+    foreach ($existing as $tid) {
+      $values[] = array(
+        'tid' => $tid,
+        'vid' => 1,
+        'vocabulary_machine_name' => 'tags'
+      );
+    }
+
+    $values = array(LANGUAGE_NONE => $values);
+
+    $settings = array(
+      'type' => 'article',
+      'field_tags' => $values,
+    );
+
+    return $this->drupalCreateNode($settings);
+  }
+}


### PR DESCRIPTION
The ultimate goal is feature parity with Drupal 8 module. This would become branch 7.x-3.x of the module. At this time it includes:
* Ability to set identity parameters
* Ability to map taxonomies
* Ability to map UDF (user defined) fields
* Configuration of Lift endpoints
* Rendering of values into meta tags similar to D8 rather than the drupalSettings settings
