### PR TITLE
[LAT-541] - load script as async

### DIFF
--- a/src/Service/Context/PageContext.php
+++ b/src/Service/Context/PageContext.php
@@ -359,6 +359,7 @@ class PageContext extends BaseContext {
         '#tag' => 'script',
         '#attributes' => [
           'src' => $this->assetsUrl . '/' . SELF::LIFT_JS_FILENAME,
+          'async',
         ],
       ],
       'acquia_lift_javascript',

--- a/tests/src/Unit/Service/Context/PageContextTest.php
+++ b/tests/src/Unit/Service/Context/PageContextTest.php
@@ -513,6 +513,7 @@ class PageContextTest extends UnitTestCase {
         '#tag' => 'script',
         '#attributes' => [
           'src' => $assetsUrl . '/lift.js',
+          'async',
         ],
       ],
       'acquia_lift_javascript',


### PR DESCRIPTION
It's best practice to load 3rd party scripts as async, in order to not block any existing customer JS. This branch just adds that attr to the SCRIPT tag to provide that as a default to all customer sights.

😋 🍏 