### PR TITLE
LEB-4383 | bring ORCA up to date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
   global:
     - ORCA_SUT_NAME=drupal/acquia_lift
     - ORCA_SUT_BRANCH=8.x-3.x
-    - ORCA_VERSION=master
+    - ORCA_VERSION=dev-master
     - ORCA_TELEMETRY_ENABLE=TRUE
 
 matrix:
@@ -39,7 +39,7 @@ matrix:
     - env: ORCA_JOB=DEPRECATED_CODE_SCAN
 
 before_install:
-  - git clone --branch ${ORCA_VERSION} --depth 1 https://github.com/acquia/orca.git ../orca
+  - composer create-project --no-dev acquia/orca ../orca "$ORCA_VERSION"
   - ../orca/bin/travis/before_install.sh
 
 install: ../orca/bin/travis/install.sh


### PR DESCRIPTION
While we don't intend to support D9 in this branch, we can still learn from #294 and bring ORCA up to date.