### PR TITLE
LEB-4601 | update ES type for source_entity, language and view_mode

### DIFF
--- a/modules/acquia_lift_publisher/src/EventSubscriber/Cdf/EntityRenderHandler.php
+++ b/modules/acquia_lift_publisher/src/EventSubscriber/Cdf/EntityRenderHandler.php
@@ -171,11 +171,11 @@ class EntityRenderHandler implements EventSubscriberInterface {
           $html = $this->renderer->renderPlain($elements);
           $metadata['data'] = base64_encode($html);
           $cdf->addAttribute('content', CDFAttribute::TYPE_STRING, trim(preg_replace('/\s+/', ' ', str_replace("\n", ' ', strip_tags($html)))));
-          $cdf->addAttribute('source_entity', CDFAttribute::TYPE_STRING, $translation->uuid());
+          $cdf->addAttribute('source_entity_id', CDFAttribute::TYPE_KEYWORD, $translation->uuid());
           $cdf->addAttribute('label', CDFAttribute::TYPE_ARRAY_STRING, $translation->label(), $translation->language()->getId());
-          $cdf->addAttribute('language', CDFAttribute::TYPE_STRING, $language->getId());
+          $cdf->addAttribute('langcode', CDFAttribute::TYPE_KEYWORD, $language->getId());
           $cdf->addAttribute('language_label', CDFAttribute::TYPE_STRING, $language->getName());
-          $cdf->addAttribute('view_mode', CDFAttribute::TYPE_STRING, $view_mode);
+          $cdf->addAttribute('view_mode_id', CDFAttribute::TYPE_KEYWORD, $view_mode);
           $cdf->addAttribute('view_mode_label', CDFAttribute::TYPE_STRING, $display->label());
 
           $preview_src = $this->buildPreviewImageAttributeSource($view_modes, 'acquia_lift_preview_image', 'acquia_lift_publisher_preview_image', $translation);
@@ -365,9 +365,9 @@ class EntityRenderHandler implements EventSubscriberInterface {
         ->listEntities([
           'type' => 'rendered_entity',
           'origin' => $this->origin,
-          'fields' => 'language,view_mode',
+          'fields' => 'langcode,view_mode_id',
           'filters' => [
-            'source_entity' => $source_uuid,
+            'source_entity_id' => $source_uuid,
           ],
         ]);
 
@@ -475,8 +475,8 @@ class EntityRenderHandler implements EventSubscriberInterface {
     foreach ($data as $entity_info) {
       $this->setStorageItem(
         $source_uuid,
-        $this->getAttributeValue($entity_info['attributes'], 'language'),
-        $this->getAttributeValue($entity_info['attributes'], 'view_mode'),
+        $this->getAttributeValue($entity_info['attributes'], 'langcode'),
+        $this->getAttributeValue($entity_info['attributes'], 'view_mode_id'),
         $entity_info['uuid']
       );
     }

--- a/modules/acquia_lift_publisher/src/EventSubscriber/Publish/PublishOnlyRendered.php
+++ b/modules/acquia_lift_publisher/src/EventSubscriber/Publish/PublishOnlyRendered.php
@@ -82,7 +82,7 @@ class PublishOnlyRendered implements EventSubscriberInterface {
         continue;
       }
 
-      $source_uuid = $this->getCdfEntityAttributeValue($cdf, 'source_entity');
+      $source_uuid = $this->getCdfEntityAttributeValue($cdf, 'source_entity_id');
       if ($source_uuid === $entity->uuid()) {
         $event->setEligibility(TRUE);
         return;
@@ -120,7 +120,7 @@ class PublishOnlyRendered implements EventSubscriberInterface {
       return;
     }
 
-    $se_uuid = $this->getCdfEntityAttributeValue($rendered_entity, 'source_entity');
+    $se_uuid = $this->getCdfEntityAttributeValue($rendered_entity, 'source_entity_id');
     if (!$se_uuid) {
       return;
     }

--- a/modules/acquia_lift_publisher/tests/src/Kernel/EventSubscriber/Cdf/EntityRenderHandlerTest.php
+++ b/modules/acquia_lift_publisher/tests/src/Kernel/EventSubscriber/Cdf/EntityRenderHandlerTest.php
@@ -329,12 +329,12 @@ class EntityRenderHandlerTest extends KernelTestBase {
     $contents = [];
 
     foreach ($cdfs as $cdf) {
-      $language = $cdf->getAttribute('language');
+      $language = $cdf->getAttribute('langcode');
       $this->assertNotNull($language, 'Entity translation has a corresponding cdf.');
       $language = $language->getValue()[LanguageInterface::LANGCODE_NOT_SPECIFIED];
       $cdf_languages[] = $language;
 
-      $source_entities[] = $cdf->getAttribute('source_entity')
+      $source_entities[] = $cdf->getAttribute('source_entity_id')
         ->getValue()[LanguageInterface::LANGCODE_NOT_SPECIFIED];
 
       $contents[$language] = $cdf->getAttribute('content')

--- a/modules/acquia_lift_publisher/tests/src/Kernel/EventSubscriber/Publish/PublishOnlyRenderedTest.php
+++ b/modules/acquia_lift_publisher/tests/src/Kernel/EventSubscriber/Publish/PublishOnlyRenderedTest.php
@@ -273,9 +273,9 @@ class PublishOnlyRenderedTest extends KernelTestBase {
     $source_entity->addAttribute('tags', CDFAttribute::TYPE_ARRAY_REFERENCE, $tag_uuids);
 
     $rendered1 = new CDFObject('rendered_entity', $uuid->generate(), $time, $time, $origin);
-    $rendered1->addAttribute('source_entity', CDFAttribute::TYPE_STRING, $source_entity->getUuid());
+    $rendered1->addAttribute('source_entity_id', CDFAttribute::TYPE_KEYWORD, $source_entity->getUuid());
     $rendered2 = new CDFObject('rendered_entity', $uuid->generate(), $time, $time, $origin);
-    $rendered2->addAttribute('source_entity', CDFAttribute::TYPE_STRING, $source_entity->getUuid());
+    $rendered2->addAttribute('source_entity_id', CDFAttribute::TYPE_KEYWORD, $source_entity->getUuid());
     $cdfs[] = $rendered1;
     $cdfs[] = $rendered2;
 


### PR DESCRIPTION
Those fields are being renamed to source_entity_id, langcode and view_mode_id respectively. This is to avoid ES index conflicts and to avoid having to reindex
ES.